### PR TITLE
Added Thaumium Pipe

### DIFF
--- a/MODSRC/vazkii/tinkerer/client/core/proxy/TTClientProxy.java
+++ b/MODSRC/vazkii/tinkerer/client/core/proxy/TTClientProxy.java
@@ -14,6 +14,7 @@
  */
 package vazkii.tinkerer.client.core.proxy;
 
+import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import vazkii.tinkerer.client.core.handler.ClientTickHandler;
 import vazkii.tinkerer.client.core.handler.HUDHandler;
@@ -32,6 +33,8 @@ import vazkii.tinkerer.common.block.tile.TileMagnet;
 import vazkii.tinkerer.common.block.tile.TileRepairer;
 import vazkii.tinkerer.common.block.tile.tablet.TileAnimationTablet;
 import vazkii.tinkerer.common.core.proxy.TTCommonProxy;
+import vazkii.tinkerer.common.item.ModItems;
+import buildcraft.transport.TransportProxyClient;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -49,6 +52,7 @@ public class TTClientProxy extends TTCommonProxy {
 		TickRegistry.registerTickHandler(new ClientTickHandler(), Side.CLIENT);
 		registerTiles();
 		registerRenderIDs();
+		MinecraftForgeClient.registerItemRenderer(ModItems.thaumiumPipe.itemID, TransportProxyClient.pipeItemRenderer);
 	}
 
 	private void registerTiles() {

--- a/MODSRC/vazkii/tinkerer/common/ThaumicTinkerer.java
+++ b/MODSRC/vazkii/tinkerer/common/ThaumicTinkerer.java
@@ -14,11 +14,15 @@
  */
 package vazkii.tinkerer.common;
 
+import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.event.ForgeSubscribe;
 import thaumcraft.common.CommonProxy;
 import thaumcraft.common.Thaumcraft;
 import vazkii.tinkerer.common.core.proxy.TTCommonProxy;
+import vazkii.tinkerer.common.item.pipe.ThaumiumPipe;
 import vazkii.tinkerer.common.lib.LibMisc;
 import vazkii.tinkerer.common.network.PacketManager;
+import vazkii.tinkerer.common.triggers.TriggerProvider;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
@@ -27,6 +31,8 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkMod;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 @Mod(modid = LibMisc.MOD_ID, name = LibMisc.MOD_NAME, version = LibMisc.VERSION, dependencies = LibMisc.DEPENDENCIES)
 @NetworkMod(clientSideRequired = true, channels = { LibMisc.NETWORK_CHANNEL }, packetHandler = PacketManager.class)
@@ -55,5 +61,16 @@ public class ThaumicTinkerer {
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event) {
 		proxy.postInit(event);
+	}
+	
+	@ForgeSubscribe
+	@SideOnly(Side.CLIENT)
+	public void loadTextures(TextureStitchEvent.Pre event) {
+		// Register mod icons
+		TriggerProvider.loadTextures(event);
+		
+		// Register Thaumium Pipe icon
+		if (event.map.textureType == 0)
+			ThaumiumPipe.registerIcons(event.map);
 	}
 }

--- a/MODSRC/vazkii/tinkerer/common/core/handler/ConfigHandler.java
+++ b/MODSRC/vazkii/tinkerer/common/core/handler/ConfigHandler.java
@@ -79,6 +79,7 @@ public final class ConfigHandler {
 		LibItemIDs.idRevealingHelm = loadItem(LibItemNames.REVEALING_HELM, LibItemIDs.idRevealingHelm);
 		LibItemIDs.idInfusedInkwell = loadItem(LibItemNames.INFUSED_INKWELL, LibItemIDs.idInfusedInkwell);
 		LibItemIDs.idFocusDeflect = loadItem(LibItemNames.FOCUS_DEFLECT, LibItemIDs.idFocusDeflect);
+		LibItemIDs.idThaumiumPipe = loadItem(LibItemNames.THAUMIUM_PIPE, LibItemIDs.idThaumiumPipe);
 		
 		LibEnchantIDs.idAscentBoost = loadEnchant(LibEnchantNames.ASCENT_BOOST, LibEnchantIDs.idAscentBoost);
 		LibEnchantIDs.idSlowFall = loadEnchant(LibEnchantNames.SLOW_FALL, LibEnchantIDs.idSlowFall);

--- a/MODSRC/vazkii/tinkerer/common/core/proxy/TTCommonProxy.java
+++ b/MODSRC/vazkii/tinkerer/common/core/proxy/TTCommonProxy.java
@@ -14,6 +14,8 @@
  */
 package vazkii.tinkerer.common.core.proxy;
 
+import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.client.event.TextureStitchEvent.Pre;
 import thaumcraft.common.tiles.TileAlembic;
 import thaumcraft.common.tiles.TileArcaneBore;
 import thaumcraft.common.tiles.TileCentrifuge;
@@ -42,6 +44,7 @@ import vazkii.tinkerer.common.network.PlayerTracker;
 import vazkii.tinkerer.common.potion.ModPotions;
 import vazkii.tinkerer.common.research.ModRecipes;
 import vazkii.tinkerer.common.research.ModResearch;
+import vazkii.tinkerer.common.triggers.TriggerProvider;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -67,6 +70,7 @@ public class TTCommonProxy {
 		ModPotions.initPotions();
 		ModBlocks.initTileEntities();
 		NetworkRegistry.instance().registerGuiHandler(ThaumicTinkerer.instance, new GuiHandler());
+		TriggerProvider.init();
 		GameRegistry.registerPlayerTracker(new PlayerTracker());
 	}
 

--- a/MODSRC/vazkii/tinkerer/common/item/ModItems.java
+++ b/MODSRC/vazkii/tinkerer/common/item/ModItems.java
@@ -15,7 +15,9 @@
 package vazkii.tinkerer.common.item;
 
 import net.minecraft.item.Item;
+import thaumcraft.common.Thaumcraft;
 import vazkii.tinkerer.common.block.ModBlocks;
+import vazkii.tinkerer.common.core.handler.ModCreativeTab;
 import vazkii.tinkerer.common.item.foci.ItemFocusDeflect;
 import vazkii.tinkerer.common.item.foci.ItemFocusDislocation;
 import vazkii.tinkerer.common.item.foci.ItemFocusEnderChest;
@@ -23,6 +25,8 @@ import vazkii.tinkerer.common.item.foci.ItemFocusFlight;
 import vazkii.tinkerer.common.item.foci.ItemFocusHeal;
 import vazkii.tinkerer.common.item.foci.ItemFocusSmelt;
 import vazkii.tinkerer.common.item.foci.ItemFocusTelekinesis;
+import vazkii.tinkerer.common.item.pipe.ItemThaumiumPipe;
+import vazkii.tinkerer.common.item.pipe.ThaumiumPipe;
 import vazkii.tinkerer.common.lib.LibItemIDs;
 import vazkii.tinkerer.common.lib.LibItemNames;
 
@@ -48,6 +52,7 @@ public final class ModItems {
 	public static Item revealingHelm;
 	public static Item infusedInkwell;
 	public static Item focusDeflect;
+	public static Item thaumiumPipe;
 
 	public static void initItems() {
 		darkQuartz = new ItemMod(LibItemIDs.idDarkQuartz).setUnlocalizedName(LibItemNames.DARK_QUARTZ);
@@ -70,5 +75,6 @@ public final class ModItems {
 		revealingHelm = new ItemRevealingHelm(LibItemIDs.idRevealingHelm).setUnlocalizedName(LibItemNames.REVEALING_HELM);
 		infusedInkwell = new ItemInfusedInkwell(LibItemIDs.idInfusedInkwell).setUnlocalizedName(LibItemNames.INFUSED_INKWELL);
 		focusDeflect = new ItemFocusDeflect(LibItemIDs.idFocusDeflect).setUnlocalizedName(LibItemNames.FOCUS_DEFLECT);
+		thaumiumPipe = ItemThaumiumPipe.registerPipe(0, ThaumiumPipe.class);
 	}
 }

--- a/MODSRC/vazkii/tinkerer/common/item/pipe/AspectPipe.java
+++ b/MODSRC/vazkii/tinkerer/common/item/pipe/AspectPipe.java
@@ -1,0 +1,16 @@
+package vazkii.tinkerer.common.item.pipe;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.ForgeDirection;
+import net.minecraftforge.fluids.IFluidHandler;
+import thaumcraft.api.aspects.IAspectContainer;
+import buildcraft.transport.PipeTransportStructure;
+
+public class AspectPipe extends PipeTransportStructure {
+
+	@Override
+	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
+		return tile != null && tile instanceof IAspectContainer && !(tile instanceof IInventory) && !(tile instanceof IFluidHandler);
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/item/pipe/ItemThaumiumPipe.java
+++ b/MODSRC/vazkii/tinkerer/common/item/pipe/ItemThaumiumPipe.java
@@ -1,0 +1,40 @@
+package vazkii.tinkerer.common.item.pipe;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
+import vazkii.tinkerer.common.core.handler.ModCreativeTab;
+import vazkii.tinkerer.common.lib.LibMisc;
+import buildcraft.transport.BlockGenericPipe;
+import buildcraft.transport.ItemPipe;
+import buildcraft.transport.Pipe;
+import buildcraft.transport.TransportProxy;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class ItemThaumiumPipe extends ItemPipe {
+
+	public ItemThaumiumPipe(int id) {
+		super(id);
+	}
+
+	@Override
+	public String getItemDisplayName(ItemStack stack) {
+		return ("" + StatCollector.translateToLocal(getUnlocalizedNameInefficiently(stack) + ".name")).trim();
+	}
+	
+	public static ItemThaumiumPipe registerPipe(int id, Class<? extends Pipe> clazz) {
+		ItemThaumiumPipe item = new ItemThaumiumPipe(id);
+		item.setUnlocalizedName(LibMisc.MOD_ID + ".thaumiumPipe");
+		item.setCreativeTab(ModCreativeTab.INSTANCE);
+
+		GameRegistry.registerItem(item, item.getUnlocalizedName());
+
+		BlockGenericPipe.pipes.put(item.itemID, clazz);
+
+		Pipe dummyPipe = BlockGenericPipe.createPipe(item.itemID);
+		if (dummyPipe != null) {
+			item.setPipeIconIndex(dummyPipe.getIconIndexForItem());
+			TransportProxy.proxy.setIconProviderFromPipe(item, dummyPipe);
+		}
+		return item;
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/item/pipe/ThaumiumPipe.java
+++ b/MODSRC/vazkii/tinkerer/common/item/pipe/ThaumiumPipe.java
@@ -1,0 +1,44 @@
+package vazkii.tinkerer.common.item.pipe;
+
+import net.minecraft.client.renderer.texture.IconRegister;
+import net.minecraft.util.Icon;
+import net.minecraftforge.common.ForgeDirection;
+import vazkii.tinkerer.common.lib.LibMisc;
+import buildcraft.api.core.IIconProvider;
+import buildcraft.transport.Pipe;
+import buildcraft.transport.PipeIconProvider;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class ThaumiumPipe extends Pipe {
+
+	@SideOnly(Side.CLIENT)
+	private static Icon icon;
+
+	public ThaumiumPipe(int itemID) {
+		super(new AspectPipe(), itemID);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public IIconProvider getIconProvider() {
+		return new PipeIconProvider() {
+
+			@Override
+			@SideOnly(Side.CLIENT)
+			public Icon getIcon(int pipeIconIndex) {
+				return ThaumiumPipe.icon;
+			}
+		};
+	}
+
+	@Override
+	public int getIconIndex(ForgeDirection direction) {
+		return 0;
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static void registerIcons(IconRegister reg) {
+		icon = reg.registerIcon(LibMisc.MOD_ID + ":" + "thaumiumPipe");
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/lib/LibItemIDs.java
+++ b/MODSRC/vazkii/tinkerer/common/lib/LibItemIDs.java
@@ -36,5 +36,6 @@ public final class LibItemIDs {
 	public static int idRevealingHelm = 22167;
 	public static int idInfusedInkwell = 22168;
 	public static int idFocusDeflect = 22169;
+	public static int idThaumiumPipe = 22170;
 	
 }

--- a/MODSRC/vazkii/tinkerer/common/lib/LibItemNames.java
+++ b/MODSRC/vazkii/tinkerer/common/lib/LibItemNames.java
@@ -38,5 +38,6 @@ public final class LibItemNames {
 	public static final String REVEALING_HELM = LibResources.PREFIX_MOD + "revealingHelm";
 	public static final String INFUSED_INKWELL = LibResources.PREFIX_MOD + "infusedInkwell";
 	public static final String FOCUS_DEFLECT = LibResources.PREFIX_MOD + "focusDeflect";
+	public static final String THAUMIUM_PIPE = LibResources.PREFIX_MOD + "thaumiumPipe";
 
 }

--- a/MODSRC/vazkii/tinkerer/common/lib/LibResearch.java
+++ b/MODSRC/vazkii/tinkerer/common/lib/LibResearch.java
@@ -60,5 +60,6 @@ public final class LibResearch {
 	public static final String KEY_REPAIRER = "REPAIRER";
 	public static final String KEY_FOCUS_DEFLECT = "FOCUS_DEFLECT";
 	public static final String KEY_ASPECT_ANALYZER = "ASPECT_ANALYZER";
+	public static final String KEY_THAUMIUM_PIPE = "THAUMIUM_PIPE";
 
 }

--- a/MODSRC/vazkii/tinkerer/common/research/ModRecipes.java
+++ b/MODSRC/vazkii/tinkerer/common/research/ModRecipes.java
@@ -22,6 +22,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.oredict.OreDictionary;
+import thaumcraft.api.ItemApi;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -143,6 +144,10 @@ public final class ModRecipes {
 			'W', new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 6),
 			'M', new ItemStack(ConfigItems.itemThaumometer),
 			'T', new ItemStack(ConfigItems.itemResource, 1, 2));
+		registerResearchItem(LibResearch.KEY_THAUMIUM_PIPE, LibResearch.KEY_THAUMIUM_PIPE, new ItemStack(ModItems.thaumiumPipe, 8), new AspectList().add(Aspect.ORDER, 2).add(Aspect.EARTH, 2).add(Aspect.FIRE, 1).add(Aspect.AIR, 1).add(Aspect.ENTROPY, 1),
+				"XYX",
+				'X', new ItemStack(ConfigItems.itemResource, 1, 2),
+				'Y', Block.glass);
 	}
 
 	private static void initInfusionRecipes() {

--- a/MODSRC/vazkii/tinkerer/common/research/ModResearch.java
+++ b/MODSRC/vazkii/tinkerer/common/research/ModResearch.java
@@ -24,6 +24,7 @@ import thaumcraft.api.crafting.CrucibleRecipe;
 import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.api.crafting.InfusionEnchantmentRecipe;
 import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.api.research.ResearchPage;
@@ -159,6 +160,9 @@ public final class ModResearch {
 
 		research = new ResearchItem("INFUSIONENCHANTMENT", LibResearch.CATEGORY_ENCHANTING, new AspectList().add(Aspect.MAGIC, 2).add(Aspect.MIND, 1).add(Aspect.WEAPON, 1).add(Aspect.ARMOR, 1).add(Aspect.TOOL, 1), -4, -2, 5, new ResourceLocation("thaumcraft", "textures/misc/r_enchant.png"));
 		research.setPages(new ResearchPage("tc.research_page.INFUSIONENCHANTMENT.1"), new ResearchPage("tc.research_page.INFUSIONENCHANTMENT.2"), new ResearchPage("tc.research_page.INFUSIONENCHANTMENT.3"), enchantPage("InfEnchRepair"), enchantPage("InfEnchHaste"), enchantPage("InfEnchPotency"), enchantPage("InfEnchFrugal"), enchantPage("InfEnchFortune"), enchantPage("InfEnch0"), enchantPage("InfEnch1"), enchantPage("InfEnch2"), enchantPage("InfEnch3"), enchantPage("InfEnch4"), enchantPage("InfEnch5"), enchantPage("InfEnch6"), enchantPage("InfEnch7"), enchantPage("InfEnch8"), enchantPage("InfEnch9"), enchantPage("InfEnch10"), enchantPage("InfEnch11"), enchantPage("InfEnch12"), enchantPage("InfEnch13"), enchantPage("InfEnch14"), enchantPage("InfEnch15"), enchantPage("InfEnch16"), enchantPage("InfEnch17"), enchantPage("InfEnch18"), enchantPage("InfEnch19"), enchantPage("InfEnch20"), enchantPage("InfEnch21")).setConcealed().setParents("JARBRAIN").registerResearchItem();
+		
+		research = new TTResearchItem(LibResearch.KEY_THAUMIUM_PIPE, LibResearch.CATEGORY_ALCHEMY, new AspectList().add(Aspect.METAL, 2).add(Aspect.MAGIC, 1).add(Aspect.MECHANISM, 1), 4, 4, 3, new ItemStack(ModItems.thaumiumPipe)).setParents(new String[] { "TUBES", "THAUMIUM" }).setConcealed();
+		research.setPages(new ResearchPage[] { new ResearchPage("tc.research_page.THAUMIUM_PIPE"), new ResearchPage((ShapedArcaneRecipe) ConfigResearch.recipes.get("THAUMIUM_PIPE")) });
 	}
 
 	private static void registerResearchPages() {

--- a/MODSRC/vazkii/tinkerer/common/triggers/AspectAmountTrigger.java
+++ b/MODSRC/vazkii/tinkerer/common/triggers/AspectAmountTrigger.java
@@ -1,0 +1,99 @@
+package vazkii.tinkerer.common.triggers;
+
+import net.minecraft.client.renderer.texture.IconRegister;
+import net.minecraft.item.Item;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Icon;
+import net.minecraftforge.common.ForgeDirection;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.aspects.IAspectContainer;
+import thaumcraft.api.aspects.IEssentiaContainerItem;
+import vazkii.tinkerer.common.lib.LibMisc;
+import buildcraft.api.gates.ITrigger;
+import buildcraft.api.gates.ITriggerParameter;
+import buildcraft.api.gates.TriggerParameter;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class AspectAmountTrigger implements ITrigger {
+
+	@SideOnly(Side.CLIENT)
+	private Icon icon;
+
+	private final String uniqueTag, description;
+	private final int amount;
+
+	public AspectAmountTrigger(int amount) {
+		uniqueTag = LibMisc.MOD_ID + ":" + "aspectTrigger" + amount;
+		description = "Aspect " + (amount > 0 ? ">= " : "< ") + Math.abs(amount);
+		this.amount = amount;
+	}
+
+	@Override
+	public String getUniqueTag() {
+		return uniqueTag;
+	}
+
+	@Override
+	public Icon getIcon() {
+		return icon;
+	}
+
+	@Override
+	public void registerIcons(IconRegister reg) {
+		icon = reg.registerIcon(LibMisc.MOD_ID + ":triggers/aspectTrigger" + Math.abs(amount));
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public boolean isTriggerActive(ForgeDirection side, TileEntity tile, ITriggerParameter parameter) {
+		if (tile != null && tile instanceof IAspectContainer) {
+			AspectList aspects = ((IAspectContainer) tile).getAspects();
+			if (aspects != null) {
+				Aspect aspect = aspects.getAspectsSortedAmount()[0];
+
+				// If trigger has a parameter
+				if (parameter != null && parameter.getItemStack() != null) {
+					Item paramItem = parameter.getItemStack().getItem();
+					if (paramItem != null && paramItem instanceof IEssentiaContainerItem) {
+						AspectList itemAspects = ((IEssentiaContainerItem) paramItem).getAspects(parameter.getItemStack());
+						if (itemAspects != null)
+							aspect = itemAspects.getAspectsSortedAmount()[0];
+					}
+				}
+
+				return testAspect(aspects, aspect, amount);
+			}
+		}
+		return false;
+	}
+
+	private boolean testAspect(AspectList aspects, Aspect aspect, int amount) {
+		return amount > 0 ? aspects.getAmount(aspect) >= amount : aspects.getAmount(aspect) < Math.abs(amount);
+	}
+
+	@Override
+	public boolean hasParameter() {
+		return true;
+	}
+
+	@Override
+	public boolean requiresParameter() {
+		return false;
+	}
+
+	@Override
+	public ITriggerParameter createParameter() {
+		return new TriggerParameter();
+	}
+
+	@Override
+	public int getLegacyId() {
+		return 0;
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/triggers/EmptyWandTrigger.java
+++ b/MODSRC/vazkii/tinkerer/common/triggers/EmptyWandTrigger.java
@@ -1,0 +1,83 @@
+package vazkii.tinkerer.common.triggers;
+
+import net.minecraft.client.renderer.texture.IconRegister;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Icon;
+import net.minecraftforge.common.ForgeDirection;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.tiles.TileWandPedestal;
+import vazkii.tinkerer.common.lib.LibMisc;
+import buildcraft.api.gates.ITrigger;
+import buildcraft.api.gates.ITriggerParameter;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class EmptyWandTrigger implements ITrigger {
+
+	@SideOnly(Side.CLIENT)
+	private Icon icon;
+
+	@Override
+	public String getUniqueTag() {
+		return LibMisc.MOD_ID + ".emptyWandTrigger";
+	}
+
+	@Override
+	public Icon getIcon() {
+		return icon;
+	}
+
+	@Override
+	public void registerIcons(IconRegister reg) {
+		icon = reg.registerIcon(LibMisc.MOD_ID + ":triggers/emptyWand");
+	}
+
+	@Override
+	public String getDescription() {
+		return "Wand is Empty";
+	}
+
+	@Override
+	public boolean isTriggerActive(ForgeDirection side, TileEntity tile, ITriggerParameter parameter) {
+		if (tile != null && tile instanceof TileWandPedestal) {
+			TileWandPedestal pedestal = (TileWandPedestal) tile;
+			ItemStack stack = pedestal.func_70301_a(0);
+			if (stack != null && stack.getItem() instanceof ItemWandCasting) {
+				ItemWandCasting wand = (ItemWandCasting) stack.getItem();
+				AspectList aspects = wand.getAllVis(stack);
+				if (aspects != null) {
+					for (Aspect aspect : aspects.getAspects())
+						if (wand.getVis(stack, aspect) <= 0)
+							continue;
+						else
+							return false;
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean hasParameter() {
+		return false;
+	}
+
+	@Override
+	public boolean requiresParameter() {
+		return false;
+	}
+
+	@Override
+	public ITriggerParameter createParameter() {
+		return null;
+	}
+
+	@Override
+	public int getLegacyId() {
+		return 0;
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/triggers/FullWandTrigger.java
+++ b/MODSRC/vazkii/tinkerer/common/triggers/FullWandTrigger.java
@@ -1,0 +1,76 @@
+package vazkii.tinkerer.common.triggers;
+
+import net.minecraft.client.renderer.texture.IconRegister;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Icon;
+import net.minecraftforge.common.ForgeDirection;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.tiles.TileWandPedestal;
+import vazkii.tinkerer.common.lib.LibMisc;
+import buildcraft.api.gates.ITrigger;
+import buildcraft.api.gates.ITriggerParameter;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class FullWandTrigger implements ITrigger {
+
+	@SideOnly(Side.CLIENT)
+	private Icon icon;
+
+	@Override
+	public String getUniqueTag() {
+		return LibMisc.MOD_ID + ".fullWandTrigger";
+	}
+
+	@Override
+	public Icon getIcon() {
+		return icon;
+	}
+
+	@Override
+	public void registerIcons(IconRegister reg) {
+		icon = reg.registerIcon(LibMisc.MOD_ID + ":triggers/fullWand");
+	}
+
+	@Override
+	public String getDescription() {
+		return "Wand is Fully Charged";
+	}
+
+	@Override
+	public boolean isTriggerActive(ForgeDirection side, TileEntity tile, ITriggerParameter parameter) {
+		if (tile != null && tile instanceof TileWandPedestal) {
+			TileWandPedestal pedestal = (TileWandPedestal) tile;
+			ItemStack stack = pedestal.func_70301_a(0);
+			if (stack != null && stack.getItem() instanceof ItemWandCasting) {
+				ItemWandCasting wand = (ItemWandCasting) stack.getItem();
+				AspectList aspects = wand.getAspectsWithRoom(stack);
+				if (aspects != null)
+					return aspects.size() == 0;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean hasParameter() {
+		return false;
+	}
+
+	@Override
+	public boolean requiresParameter() {
+		return false;
+	}
+
+	@Override
+	public ITriggerParameter createParameter() {
+		return null;
+	}
+
+	@Override
+	public int getLegacyId() {
+		return 0;
+	}
+}

--- a/MODSRC/vazkii/tinkerer/common/triggers/TriggerProvider.java
+++ b/MODSRC/vazkii/tinkerer/common/triggers/TriggerProvider.java
@@ -1,0 +1,77 @@
+package vazkii.tinkerer.common.triggers;
+
+import java.util.LinkedList;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.fluids.IFluidHandler;
+import thaumcraft.api.aspects.IAspectContainer;
+import thaumcraft.common.tiles.TileWandPedestal;
+import buildcraft.api.gates.ActionManager;
+import buildcraft.api.gates.ITrigger;
+import buildcraft.api.gates.ITriggerProvider;
+import buildcraft.api.transport.IPipe;
+
+public class TriggerProvider implements ITriggerProvider {
+
+	public static ITrigger aspectTrigger64 = new AspectAmountTrigger(64);
+	public static ITrigger aspectTrigger32 = new AspectAmountTrigger(32);
+	public static ITrigger aspectTrigger16 = new AspectAmountTrigger(16);
+	public static ITrigger aspectTrigger08 = new AspectAmountTrigger(8);
+	public static ITrigger aspectTriggerMinus8 = new AspectAmountTrigger(-8);
+	public static ITrigger fullWandTrigger = new FullWandTrigger();
+	public static ITrigger emptyWandTrigger = new EmptyWandTrigger();
+	
+	public static void init() {
+		
+		// Register BuildCraft triggers
+		ActionManager.registerTrigger(aspectTriggerMinus8);
+		ActionManager.registerTrigger(aspectTrigger08);
+		ActionManager.registerTrigger(aspectTrigger16);
+		ActionManager.registerTrigger(aspectTrigger32);
+		ActionManager.registerTrigger(aspectTrigger64);
+		ActionManager.registerTrigger(fullWandTrigger);
+		ActionManager.registerTrigger(emptyWandTrigger);
+
+		ActionManager.registerTriggerProvider(new TriggerProvider());
+	}
+	
+	public static void loadTextures(TextureStitchEvent.Pre event) {
+		if (event.map.textureType == 1) {
+			aspectTrigger64.registerIcons(event.map);
+			aspectTrigger32.registerIcons(event.map);
+			aspectTrigger16.registerIcons(event.map);
+			aspectTrigger08.registerIcons(event.map);
+			aspectTriggerMinus8.registerIcons(event.map);
+			fullWandTrigger.registerIcons(event.map);
+			emptyWandTrigger.registerIcons(event.map);
+		}
+	}
+	
+	@Override
+	public LinkedList<ITrigger> getPipeTriggers(IPipe pipe) {
+		return null;
+	}
+
+	@Override
+	public LinkedList<ITrigger> getNeighborTriggers(Block block, TileEntity tile) {
+		LinkedList<ITrigger> list = new LinkedList<ITrigger>();
+
+		if (tile != null && tile instanceof IAspectContainer && !(tile instanceof IInventory) && !(tile instanceof IFluidHandler)) {
+			list.add(aspectTriggerMinus8);
+			list.add(aspectTrigger08);
+			list.add(aspectTrigger16);
+			list.add(aspectTrigger32);
+			list.add(aspectTrigger64);
+		}
+
+		if (tile instanceof TileWandPedestal) {
+			list.add(fullWandTrigger);
+			list.add(emptyWandTrigger);
+		}
+
+		return list;
+	}
+}

--- a/resources/assets/ttinkerer/lang/en_US.lang
+++ b/resources/assets/ttinkerer/lang/en_US.lang
@@ -49,6 +49,7 @@ item.ttinkerer:bloodSword.name=Cursed Spirit's Blade
 item.ttinkerer:revealingHelm.name=Helmet of Revealing
 item.ttinkerer:infusedInkwell.name=Infused Scribing Tools
 item.ttinkerer:focusDeflect.name=Wand Focus: Distortion
+item.ttinkerer:thaumiumPipe.name=Thaumium Pipe
 
 # BLOCK NAMES
 tile.ttinkerer:darkQuartz.name=Block of Smokey Quartz
@@ -251,3 +252,8 @@ ttresearch.page.REPAIRER.0=You created a new contraption to restore broken tools
 ttresearch.name.FOCUS_DEFLECT=Wand Focus: Distortion
 ttresearch.lore.FOCUS_DEFLECT=I'm not an Angel
 ttresearch.page.FOCUS_DEFLECT.0=You created a focus to protect you from incoming fire.<BR><BR>This focus, when in use, will constantly drain vis from the wand it's inserted on, in order to summon a ward around the caster, making ordinary projectiles pass through them harmlessly.<BR><BR>Ordinary projectiles include arrows, snowballs or potions. It seems the ward is not strong enough to displace stronger attacks, like fireballs or wither heads.
+
+# — THAUMIUM PIPE
+ttresearch.name.THAUMIUM_PIPE=Thaumium Pipe
+ttresearch.lore.THAUMIUM_PIPE=When technology and magic work together
+ttresearch.page.THAUMIUM_PIPE=This pipe cannot be used as a normal BuildCraft pipe, it will not transport items, fluids or energy. It does not transport anything as a matter of fact. But its uses are plenty!<BR>This pipe connects only to aspect containers. It cannot pull the aspects out, but it allows you to measure them using gates. If the container has more than one aspect, the pipe will measure the most abundant one. Or, you can force the pipe to measure a specific aspect by setting a filter. Placing any aspect container items on the filter will force the pipe to measure only the aspect present in that item and ignore all others.


### PR DESCRIPTION
You'll need to add BuildCraft to the build path in order for this to work.

The pipe triggers don't work on build craft versions bellow 4.2.0. Gates before that didn't take NBT into consideration. I had to get a PM in in order for this to work. It won't crash, it will only not filter the essentia.

I probably did stuff in ways you don't like, feel free to tell me what you want changing and I'll adapt the PR.
(or if you want you can change whatever you want yourself)
