### PR TITLE
 Lots of spelling, grammar, diction, and punctuation fixes to en_US

### DIFF
--- a/resources/assets/ttinkerer/lang/en_US.lang
+++ b/resources/assets/ttinkerer/lang/en_US.lang
@@ -3,14 +3,14 @@ itemGroup.ThaumicTinkerer=Thaumic Tinkerer
 ttmisc.connector.set=Location Set!
 ttmisc.connector.complete=Binding Complete!
 ttmisc.connector.notinterf=Not a Transvector Block.
-ttmisc.connector.interffail=Can't bind a Transvector Interface to another.
-ttmisc.connector.dislfail=Can't bind a Transvector Dislocator to another.
+ttmisc.connector.interffail=Can't bind one Transvector Interface to another.
+ttmisc.connector.dislfail=Can't bind one Transvector Dislocator to another.
 ttmisc.connector.notpresent=The Transvector Block isn't present.
 ttmisc.connector.toofar=The Transvector Block of origin is too far away.
 ttmisc.leftClick=Left Click
 ttmisc.rightClick=Right Click
 ttmisc.redstoneControl=Redstone Control
-ttmisc.animationTablet.notRotatable=You can not rotate the Tablet while it's activated.
+ttmisc.animationTablet.notRotatable=Can't rotate the Tablet while it's activated.
 ttmisc.focusDislocation.tooltip=Currently Dislocating
 ttmisc.focusDislocation.tooltipExtra=Extra Contents
 ttmisc.inactive=§cInactive
@@ -28,7 +28,7 @@ ttmisc.full=§cFull
 ttmisc.notAbsorbing=§cNot Absorbing
 ttmisc.absorbing=§aAbsorbing
 ttmisc.shareTome.write=Research Written!
-ttmisc.shareTome.notOnline=The player who this research belongs to is not online.
+ttmisc.shareTome.notOnline=The player whom this research belongs to is not online.
 ttmisc.shareTome.sync=Research Acquired.
 ttmisc.shareTome.noAssign=Not Assigned
 ttmisc.shareTome.playerName=Bound to %s's research.
@@ -48,7 +48,7 @@ ttmisc.mode.sword.1=Area Mode
 ttmisc.mode.sword.2=Soul Mode
 
 # ITEM NAMES
-item.ttinkerer:darkQuartz.name=Smokey Quartz
+item.ttinkerer:darkQuartz.name=Smoky Quartz
 item.ttinkerer:connector.name=Transvector Binder
 item.ttinkerer:gaseousLight.name=Gaseous Illuminae
 item.ttinkerer:gaseousShadow.name=Gaseous Tenebrae
@@ -60,7 +60,7 @@ item.ttinkerer:cleansingTalisman.name=Talisman of Remedium
 item.ttinkerer:brightNitor.name=Hyperenergetic Nitor
 item.ttinkerer:focusTelekinesis.name=Wand Focus: Telekinesis
 item.ttinkerer:soulMould.name=Soul Mould
-item.ttinkerer:xpTalisman.name=Talisman of Withhold
+item.ttinkerer:xpTalisman.name=Talisman of Withholding
 item.ttinkerer:focusSmelt.name=Wand Focus: Efreet's Flame
 item.ttinkerer:focusHeal.name=Wand Focus: Mending
 item.ttinkerer:focusEnderChest.name=Wand Focus: Ender Rift
@@ -102,11 +102,11 @@ item.ttinkerer:blockTalisman.name=Black Hole Talisman
 item.ttinkerer:placementMirror.name=Worldshaper's Looking Glass
 
 # BLOCK NAMES
-tile.ttinkerer:darkQuartz.name=Block of Smokey Quartz
-tile.ttinkerer:darkQuartzChiseled.name=Chiseled Smokey Quartz Block
-tile.ttinkerer:darkQuartzPillar.name=Pillar Smokey Quartz Block
-tile.ttinkerer:darkQuartzSlab.name=Smokey Quartz Slab
-tile.ttinkerer:darkQuartzStairs.name=Smokey Quartz Stairs
+tile.ttinkerer:darkQuartz.name=Block of Smoky Quartz
+tile.ttinkerer:darkQuartzChiseled.name=Chiseled Smoky Quartz Block
+tile.ttinkerer:darkQuartzPillar.name=Pillar Smoky Quartz Block
+tile.ttinkerer:darkQuartzSlab.name=Smoky Quartz Slab
+tile.ttinkerer:darkQuartzStairs.name=Smoky Quartz Stairs
 tile.ttinkerer:interface.name=Transvector Interface
 tile.ttinkerer:animationTablet.name=Dynamism Tablet
 tile.ttinkerer:magnet.name=Kinetic Attractor
@@ -138,7 +138,7 @@ tc.research_category.TT_ENCHANTING=Enchanting
 # -- COMPUTERCRAFT PERIPHERALS
 ttresearch.name.PERIPHERALS=Computercraft Peripherals
 ttresearch.lore.PERIPHERALS=When technology meets magic
-ttresearch.page.PERIPHERALS.0=Thaumic Tinkerer allows for some of the blocks that it adds, alongside some vanilla Thaumcraft blocks, to be used as ComputerCraft peripherals.<BR><BR>For convenience sake, the method documentation for these peripherals is in an external webpage. Pressing ENTER right now will take you to it.<BR><BR>Sadly, this does not work on some systems. If that is the case, type in "vazkii.us/tt/docs.php" in your browser.
+ttresearch.page.PERIPHERALS.0=Thaumic Tinkerer allows for some of the blocks that it adds, alongside some vanilla Thaumcraft blocks, to be used as ComputerCraft peripherals.<BR><BR>For convenience, the method documentation for these peripherals is in an external webpage. Pressing ENTER right now will take you to it.<BR><BR>Sadly, this does not work on some systems. If that is the case, type in "vazkii.us/tt/docs.php" in your browser.
 # Note: For people who localize the mod. If you have custom documentation, feel free to include in your PR a
 # link to it and the short URL (see above) you want for it on my website and I'll add it. 
 ttresearch.webpage.peripherals=https://github.com/Vazkii/ThaumicTinkerer/wiki/Peripheral-Documentation
@@ -146,273 +146,273 @@ ttresearch.webpage.peripherals=https://github.com/Vazkii/ThaumicTinkerer/wiki/Pe
 # -- ASPECT ANALYZER
 ttresearch.name.ASPECT_ANALYZER=Aspectalyzer
 ttresearch.lore.ASPECT_ANALYZER=Computerized Scanning
-ttresearch.page.ASPECT_ANALYZER.0=You created a device that allows Computers to know what aspects an item has.<BR><BR>This block acts like a normal inventory, any items in it can be scanned by use of a Computer. Visit the peripheral documentation entry for more info.
+ttresearch.page.ASPECT_ANALYZER.0=You have created a device that allows Computers to analyze the aspects in items!<BR><BR>This block acts like a normal inventory. Any items in it can be scanned using a Computer. Visit the peripheral documentation entry for more info.
 
-# -- SMOKEY QUARTZ
-ttresearch.name.DARK_QUARTZ=Smokey Quartz
+# -- SMOKY QUARTZ
+ttresearch.name.DARK_QUARTZ=Smoky Quartz
 ttresearch.lore.DARK_QUARTZ=Shadow of the Day
-ttresearch.page.DARK_QUARTZ.0=Smokey Quartz is pretty much Quartz, but negative. All regular blocks that can be made with quartz, can also be made with smokey quartz, and they look black.<BR><BR>Smokey Quartz itself can be made with a piece of coal or charcoal for tinting, and a few pieces of regular nether quartz.
+ttresearch.page.DARK_QUARTZ.0=Smoky Quartz is pretty much Quartz, but negative. All regular blocks that can be made with quartz can also be made with smoky quartz, and they look black.<BR><BR>Smoky Quartz can be made with a piece of coal or charcoal for tinting, and a few pieces of regular nether quartz.
 
 # -- TOME OF KNOWLEDGE SHARING
 ttresearch.name.SHARE_TOME=Tome of Knowledge Sharing
 ttresearch.lore.SHARE_TOME=A Goldfish's Diary
-ttresearch.page.SHARE_TOME.0=If one day you happen to want to share your knowledge with the rest of the world, this is the item for you.<BR><BR>By simply right clicking on this tome and handing it to someone else while you're logged on to the server, they'll get all the research you've discovered so far.<BR><BR>(Note: Case there being no recipe on the right of this, the recipe is disabled and the item is creative only)
+ttresearch.page.SHARE_TOME.0=If one day you happen to want to share your knowledge with the rest of the world, this is the item for you!<BR><BR>By simply right clicking on this tome and handing it to someone else while you're logged into the server, they'll get all the research you've discovered so far.<BR><BR>(Note: If there is no recipe to the right of this page, the recipe is disabled and the item is creative only)
 
 # -- TRANSVECTOR INTERFACE
 ttresearch.name.INTERFACE=Transvector Interface
 ttresearch.lore.INTERFACE=Not affiliated with nyuu
-ttresearch.page.INTERFACE.0=The thing is, there's only six sides to a block..." - Direwolf20<BR><BR>Myth = Busted! Your latest construct can be bound to a block in the nearby vacinity. It's sides will mimic the sides of the block selected, and it'll function as an extension. It can accept BuildCraft, TE3 and IC2 power, essentia, items, and liquids, being able to also export the latter two.<BR>[continued]
-ttresearch.page.INTERFACE.1=In order to bind an interface to another block, you need to create a special tool to do so. What you call the Transvector Binder should get the job done.<BR><BR>By simply right clicking on the interface followed by right clicking on the target, these two get bound and ready for operation. The limit is short, only 4 blocks. (Note: buildcraft pipes need to be broken and replaced to work)
-ttresearch.page.INTERFACE.2=It's also possible, by right clicking this block with any other to camouflage it as the block held. To remove to cover, simply right click on the camouflaged block with an empty hand.
+ttresearch.page.INTERFACE.0="The thing is, there are only six sides to a block..." - Direwolf20<BR><BR>Myth = Busted! Your latest construct can be bound to a block in the vicinity. Its sides will mimic the sides of the block selected, and it will function as an extension. It can accept BuildCraft, TE3 and IC2 power, essentia, items, and liquids, and can also export items and liquids.<BR>[continued]
+ttresearch.page.INTERFACE.1=In order to bind an Interface to another block, you need to create a special tool: the Transvector Binder.<BR><BR>By simply right clicking on the Interface followed by right clicking on the target, the two get bound and ready for operation. The Interface needs to be close to its associated block: no more than 4 blocks away. (Note: BuildCraft pipes need to be broken and replaced to work)
+ttresearch.page.INTERFACE.2=It's also possible, by right clicking the Interface with any other block, to camouflage it as the held block. To remove the camouflage, simply right click the Interface with an empty hand.
 
 # -- GASEOUS ILLUMINAE
 ttresearch.name.GASEOUS_LIGHT=Gaseous Illuminae
 ttresearch.lore.GASEOUS_LIGHT=Bright out of sight
-ttresearch.page.GASEOUS_LIGHT.0=You have studied the intricacies of the light, and found out a way to create completely invisible light by infusing a phial with the raw light.<BR><BR>This phial contains a concentrated extract of Gaseous Illuminae, that can be released through a right click, and will spread relatively fast in the nearby area, lighting it up.
+ttresearch.page.GASEOUS_LIGHT.0=Studying the intricacies of Light, you have discovered a way to create completely invisible light by infusing a phial with raw light.<BR><BR>This phial contains a concentrated extract of Gaseous Illuminae that can be released through a right click. Once released, it will spread fairly quickly in the nearby area, lighting it up.
 
 # -- GASEOUS TENEBRAE
 ttresearch.name.GASEOUS_SHADOW=Gaseous Tenebrae
 ttresearch.lore.GASEOUS_SHADOW=A red handball?
-ttresearch.page.GASEOUS_SHADOW.0=You have studied the intricacies of the Shadow, and found out a way to create gaseous darkness by infusing a phial with the raw shadow.<BR><BR>This phial contains a concentrated extract of Gaseous Tenebrae, that can be released through a right click, and will spread relatively fast in the nearby area, darkening it.
+ttresearch.page.GASEOUS_SHADOW.0=Studying the intricacies of Shadow, you have discovered a way to create gaseous darkness by infusing a phial with raw shadow.<BR><BR>This phial contains a concentrated extract of Gaseous Tenebrae that can be released through a right click. Once released, it will spread fairly quickly in the nearby area, darkening it.
 
 # -- FUME DISSIPATOR
 ttresearch.name.GAS_REMOVER=Fume Dissipator
 ttresearch.lore.GAS_REMOVER=Ryuuji's helper
-ttresearch.page.GAS_REMOVER.0=After knowing both the Gaseous Illuminae and Tenebrae, you are thinking it's becoming a hassle to get rid of it. With this item, by shift-right clicking on it, all the nearby gas will get dissipated.
+ttresearch.page.GAS_REMOVER.0=One problem with both Gaseous Illuminae and Tenebrae: it's becoming a hassle to get rid of it! By shift-right-clicking on this item, all the nearby gas will dissipate.
 
 # -- SPELLBINDING CLOTH
 ttresearch.name.SPELL_CLOTH=Spellbinding Cloth
 ttresearch.lore.SPELL_CLOTH=The sad palmtop thaumaturge
-ttresearch.page.SPELL_CLOTH.0=By mixing some Enchanted Fabric with raw magic power, you created a cloth that can be rubbed on an item to wipe it of its enchantments by combining them in a Crafting Recipe.
+ttresearch.page.SPELL_CLOTH.0=By mixing some Enchanted Fabric with raw magic power, you have createed a cloth that can rub enchantments off items! Just combine the Cloth and the enchanted item in a Crafting Table.
 
 # -- DYNAMISM TABLET
 ttresearch.name.ANIMATION_TABLET=Dynamism Tablet
 ttresearch.lore.ANIMATION_TABLET=I'm level 78...
-ttresearch.page.ANIMATION_TABLET.0=You decided to further discover the uses of Golem Animation Cores, and this is the fruit of that labour.<BR><BR>This tablet can accept an item to animate with mystical energy. Using the left and right buttons in the tablet's interface, you can select to do a left or right click with the item. The button in the bottom controls if the tablet reacts always when it can or just when a redstone signal is applied.<BR><BR>Virtually anything can be animated, including blocks. The type of tool in the tablet also defines how fast something breaks, as expected.
+ttresearch.page.ANIMATION_TABLET.0=While researching Golem Animation Cores, you found something amazing!<BR><BR>This tablet can accept an item to animate with mystical energy. Using the left and right buttons in the tablet's interface, you can select a left or a right click action using the item. The button at the bottom controls if the tablet always reacts when it can or just when a redstone signal is applied.<BR><BR>Virtually anything can be animated, including blocks. The type of tool in the tablet also defines how fast something breaks, as expected.
 
 # -- WAND FOCUS: UPRISING
 ttresearch.name.FOCUS_FLIGHT=Wand Focus: Uprising
-ttresearch.lore.FOCUS_FLIGHT=Is this what they use in ALfheim?
-ttresearch.page.FOCUS_FLIGHT.0=Using the knowledge you got from creating the Sword of the Zephyr of propelling things around with air, you created a wand focus that will propel the holder in the direction that they're looking at.<BR><BR>When someone is propelled through the use of this focus, any accumulated gravitational energy is negated, reseting the fall damage the holder would take.
+ttresearch.lore.FOCUS_FLIGHT=Is this what they use in Alfheim?
+ttresearch.page.FOCUS_FLIGHT.0=Using the knowledge of propelling things around with air that you obtained from creating the Sword of the Zephyr, you have created a wand focus that will propel the holder in the direction they're looking.<BR><BR>When propelled by this focus, any accumulated gravitational energy is safely discarded, negating the fall damage the holder would otherwise take.
 
 # -- WAND FOCUS: DISLOCATION
 ttresearch.name.FOCUS_DISLOCATION=Wand Focus: Dislocation
 ttresearch.lore.FOCUS_DISLOCATION=Build the castle within your mind so it never falls down
-ttresearch.page.FOCUS_DISLOCATION.0=You created a wand focus based on the focus of equal trade. The difference is that this one not only holds the object's fingerprint, but it holds the object itself, allowing it to be placed elsewhere.<BR><BR>To get a block to transport, right click on it. To place it back, right click somewhere else. This focus can transport pretty much anything, including chests and mob spawners.
-ttresearch.page.FOCUS_DISLOCATION.1=The vis cost in applied in picking up the block. Placing it down is free.<BR><BR>Due to the amount of energy required for the dislocation, blocks with tile entities (such as chests and furnaces) cost 5x the amount of vis as normally. Mob spawners, in particular, cost 20x instead.
+ttresearch.page.FOCUS_DISLOCATION.0=You have created a variant of the focus of Equal Trade. The difference is that this focus holds not a block's fingerprint but the block itself, allowing it to be placed elsewhere.<BR><BR>To absorb a block into the focus, right click on it. To place it back, right click somewhere else. This focus can transport pretty much anything, including chests and mob spawners.
+ttresearch.page.FOCUS_DISLOCATION.1=The vis cost in applied in picking up the block; placing it down is free.<BR><BR>Due to the amount of energy required for dislocation, blocks with tile entities (such as chests and furnaces) cost 5x the amount of vis as other blocks. Mob spawners cost 20x instead.
 
 # -- TALISMAN OF REMEDIUM
 ttresearch.name.CLEANSING_TALISMAN=Talisman of Remedium
 ttresearch.lore.CLEANSING_TALISMAN=Mitsukake's Gift
-ttresearch.page.CLEANSING_TALISMAN.0=You have studied life and the body and found that through the application of magic you can protect yourself from harmful outside influences by redirecting these effects to a construct. This talisman will dispell most harmful effects on the holder and keep them on itself, taking damage.<BR><BR>To enable or disable this ability, one would shift-right click on it. As expected, it only works whilst enabled.
+ttresearch.page.CLEANSING_TALISMAN.0=Through your studies of life and the body, you have discovered how to protect yourself from harmful outside influences by redirecting these effects to a construct. This Talisman will dispel most harmful effects on the holder and keep them on itself instead, taking damage.<BR><BR>To enable or disable this ability, shift-right click on it. As expected, it only works when enabled.
 
 # -- HYPERNERGETIC NITOR
 ttresearch.name.BRIGHT_NITOR=Hyperenergetic Nitor
 ttresearch.lore.BRIGHT_NITOR=Take that, Twilight!
-ttresearch.page.BRIGHT_NITOR.0=You managed to create a light that will shine even if it's being carried by a player by energizing the everburning flame that is Nitor with powerful energetic aspects such as Potentia and Lux.<BR><BR>The light casted by this will shine closely behind the carrier, it seems to leave a longer trail in the Nether, due to the heat.
+ttresearch.page.BRIGHT_NITOR.0=You have managed to create a light that will shine even if it's being carried by energizing the ever-burning flame that is Nitor with powerful energetic aspects such as Potentia and Lux.<BR><BR>The light cast by this will shine closely behind the carrier. It seems to leave a longer trail in the Nether, probably due to the heat.
 
 # -- WAND FOCUS: TELEKINESIS
 ttresearch.name.FOCUS_TELEKINESIS=Wand Focus: Telekinesis
 ttresearch.lore.FOCUS_TELEKINESIS=Beats gravity bubbles any day
-ttresearch.page.FOCUS_TELEKINESIS.0=You created a wand focus that kinetically moves objects laying on the floor. This focus will move any nearby items to where you're pointing at. Sneaking will bring the items towards you instead.
+ttresearch.page.FOCUS_TELEKINESIS.0=You have created a wand focus that moves objects lying on the floor. This focus will move any nearby items to where you're pointing. Sneaking will bring the items towards you instead.
 
 # -- KINETIC ATTRACTION
 ttresearch.name.MAGNETS=Kinetic Attraction
 ttresearch.lore.MAGNETS=How do they work?
-ttresearch.page.MAGNETS.0=Working with the telekinesis focus, you managed to apply this knowledge to create a device to attract items or living beings, like a magnet.<BR><BR>These two blocks have two states, north (red) and south (blue), in north mode it'll push items, or entities away; in south mode it'll pull them in.<BR><BR>The range of the attraction depends on the redstone signal applied to it. A lever next to it will allow for 7.5 blocks, while a current from farther away will make it shorter. In general, the attraction is equal to half the redstone signal's strength in blocks, in every direction.
-ttresearch.page.MAGNETS.1=You designed two devices. The Kinetic and Corporeal Attractors, these, respectively affect items and living beings.<BR><BR>The Corporeal Attractor involves some more complex mechanisms, to which you can access by right clicking it with a casting wand. Using a Soul Mould, you can right click on a mob to save it as a pattern, which you can set in the attractor's interface, as a filter, along with settings for child or adult animals, if available.
+ttresearch.page.MAGNETS.0=Modifying the technique behind the Telekinesis focus, you have created a device to attract items and living beings, like a magnet.<BR><BR>These two blocks have two modes: repelling (red) and attracting (blue). In the repelling mode it pushes items and entities away, while in the attracting  mode it pulls them in.<BR><BR>The range of the attraction depends on the redstone signal applied to it. A lever next to it will allow for 7.5 blocks, while a weaker current will make its range shorter. In general, the attraction is equal to half the redstone signal's strength in blocks, in every direction.
+ttresearch.page.MAGNETS.1=You design two devices: the Kinetic and Corporeal Attractors. They affect items and living beings, respectively.<BR><BR>The Corporeal Attractor has more complex mechanisms that you can access by right clicking it with a casting wand. Using a Soul Mould, you can right click on a mob to save it as a pattern, which you can set in the Attractor's interface as a filter, along with settings for child or adult animals, if applicable.
 
 # -- OSMOTIC ENCHANTER
 ttresearch.name.ENCHANTER=Osmotic Enchanter
 ttresearch.lore.ENCHANTER=Picking your luck
-ttresearch.page.ENCHANTER.0=You grew tired of getting terrible enchantments for your efforts. To that, you created a new enchantment table that allows you to pick what enchantments you want to apply to an item.<BR><BR>This new contraption requires a wand, each enchantment requires a specific combination of vis from that wand. The price of the enchantment is exponentially proportional to the level you want to apply.<BR><BR>Regular enchantment rules apply, for example, you can't combine Silk Touch with Fortune.
-ttresearch.page.ENCHANTER.1=After you selected the enchantments you want on an item, clicking the red button in the interface will start the enchanting progress. As the item is being enchanted, you can't take it out of the table, nor can you change the enchantments you are putting on it.<BR><BR>The table will slowly drain vis from the wand, until it's done. For this to work, there needs to be 6 pillars in the nearby vicinity (4 blocks), these pillars need to be at the same level of the table.<BR><BR>[continued]
-ttresearch.page.ENCHANTER.2=The pillars need to be made of two to twelve Obsidian Totem blocks stacked on top of each other, with a piece of Nitor on top of them. The enchanter will get flux energy from them, grabbing vis from the wand and combining them to enchant the item.<BR><BR>Lastly, the enchanter will cease to function with iron or copper capped wands, due to them being too rustic and basic for the complex infusions required.
+ttresearch.page.ENCHANTER.0=You have grown tired of getting terrible enchantments from the Enchantment Table. You have fashioned a new Enchantment Table that allows you to pick the enchantments you want.<BR><BR>This new contraption requires a wand, and each enchantment requires a specific combination of vis from that wand. The price of the enchantment grows exponentially with the level of enchantment you want to apply.<BR><BR>Regular enchantment rules apply; for example, you cannot combine Silk Touch with Fortune.
+ttresearch.page.ENCHANTER.1=After you select the enchantments you want on an item, clicking the red button in the interface will commence the enchantment process. While the item is being enchanted, you cannot take it out of the table, nor can you change the enchantments you are putting on it.<BR><BR>The Enchanter will slowly drain vis from the wand until the enchantments have been applied. The Enchanter requires 6 pillars in the nearby vicinity (4 blocks) at the same level of the table.<BR><BR>[continued]
+ttresearch.page.ENCHANTER.2=Each pillar needs to be made of two to twelve stacked Obsidian Totem blocks, with a piece of Nitor on top. The Enchanter will get Flux from the pillars, combining it with the vis from the wand to enchant the item.<BR><BR>Lastly, the Enchanter will not function with iron or copper capped wands, which are too primitive to support the complex enchantment process.
 
-# -- TALISMAN OF WITHHOLD
-ttresearch.name.XP_TALISMAN=Talisman of Withhold
+# -- TALISMAN OF WITHHOLDING
+ttresearch.name.XP_TALISMAN=Talisman of Withholding
 ttresearch.lore.XP_TALISMAN=I'll take your 'time'
-ttresearch.page.XP_TALISMAN.0=After knowing that Zombie Brains have the ability to store experience, you have created a talisman that mimics that behaviour, not to a perfect extent though.<BR><BR>To switch the ability to store experience, you need to shift-right-click on the talisman. When the talisman is enabled, it'll absorb any nearby experience orbs, those can be transformed back into usable experience by right clicking with a glass bottle in your inventory, turning that bottle into a Bottle o' Enchanting.
+ttresearch.page.XP_TALISMAN.0=Now that you know how Zombie Brains can store experience, you have created a talisman that mimics that behaviour, approximately.<BR><BR>To switch its ability to store experience, you need to shift-right-click on the talisman. When the talisman is enabled, it will absorb any nearby experience orbs. The absorbed experience can be turned into Bottles o' Enchanting by placing glass bottles in your inventory and right clicking the Talisman.
 
 # -- ESSENTIA FUNNEL
 ttresearch.name.FUNNEL=Essentia Funnel
 ttresearch.lore.FUNNEL=Even transfer
-ttresearch.page.FUNNEL.0=You grew tired of managing your jars with phials, to that, you created this new mechanism to transfer the contents of one into another.<BR><BR>By placing this block above a hopper, and right clicking it with a filled jar, if the hopper is pointing into a jar that's either empty or of the same aspect, the contents of the jar will be transfered over.
+ttresearch.page.FUNNEL.0=There has got to be a better way to manage jars than juggling phials! After some research, you have created a new mechanism to transfer the contents of one jar to another.<BR><BR>By placing this block above a hopper and right clicking it with a filled jar, the essentia will empty out into the jar that the hopper points to. For this to work, the target jar must be empty or must hold the same type of essentia as the source.
 
 # -- ENCHANTMENT: ASCENT BOOST
 ttresearch.name.TTENCH_ASCENT_BOOST=Enchantment: Ascent Boost
 ttresearch.lore.TTENCH_ASCENT_BOOST=Over Wall Maria
-ttresearch.page.TTENCH_ASCENT_BOOST.0=You have formulated an enchantment that allows you to jump higher than you normally can.<BR><BR>This enchantment can be applied on leg armor. When done so, the wearer will be able to jump a lot higher than normal.
+ttresearch.page.TTENCH_ASCENT_BOOST.0=You have formulated an enchantment that allows you to jump much higher than you normally can.<BR><BR>This enchantment can only be applied on leg armor.
 
 # -- ENCHANTMENT: SLOW FALL
 ttresearch.name.TTENCH_SLOW_FALL=Enchantment: Slow Fall
 ttresearch.lore.TTENCH_SLOW_FALL=M.A.G.E.
-ttresearch.page.TTENCH_SLOW_FALL.0=You have formulated an enchantment that allows you to fall slowly.<BR><BR>This enchantment can be applied on foot armor. When done so, the wearer will fall at a slower rate, this will also reduce, if not negating the fall damage.<BR><BR>Pressing Shift will temporarily disable this effect allowing you to fall normally.
+ttresearch.page.TTENCH_SLOW_FALL.0=You have formulated an enchantment that allows you to fall slowly.<BR><BR>This enchantment can only be applied on foot armor. The wearer will not only fall slower, but will also take reduced fall damage, which can even be negated entirely!<BR><BR>Sneaking will temporarily disable this effect, allowing you to fall normally.
 
 # -- ENCHANTMENT: FLAMING TOUCH
 ttresearch.name.TTENCH_AUTO_SMELT=Enchantment: Flaming Touch
 ttresearch.lore.TTENCH_AUTO_SMELT=Rekka Shinen!
-ttresearch.page.TTENCH_AUTO_SMELT.0=You have formulated an enchantment that allows you to summon imaginary flames.<BR><BR>This enchantment can be applied on tools. When done so, the wielder can break anything wooden with extreme finesse, by use of a flame that softens the wood through the breaking process, but never destroying or damaging it. However, the tool becomes impotent against anything else, and takes double durability damage.
+ttresearch.page.TTENCH_AUTO_SMELT.0=You have formulated an enchantment that allows you to summon simulated fire.<BR><BR>This enchantment can only be applied on tools and allows the tools to break anything wooden with extreme ease. The simulacrum softens the wood, but never destroying or damages items. Unfortunately, the tool becomes unsuitable  for anything else, and takes double durability damage.
 
-# -- ENCHANTMENT: DESINTEGRATE
-ttresearch.name.TTENCH_DESINTEGRATE=Enchantment: Desintegrate
+# -- ENCHANTMENT: DISINTEGRATE
+ttresearch.name.TTENCH_DESINTEGRATE=Enchantment: Disintegrate
 ttresearch.lore.TTENCH_DESINTEGRATE=Spacequake alert
-ttresearch.page.TTENCH_DESINTEGRATE.0=You have formulated an enchantment that allows you to mine soft materials at incredible speeds.<BR><BR>This enchantment can be applied on tools. When done so, the wielder can break regular blocks (dirt, stone, netherrack, etc.) that the tool is good for with extreme finesse, however, the tool becomes impotent against anything else, and takes double durability damage.
+ttresearch.page.TTENCH_DESINTEGRATE.0=You have formulated an enchantment that allows you to mine soft materials at incredible speeds.<BR><BR>This enchantment can only be applied on tools and allows the tool to break regular blocks (dirt, stone, netherrack, etc.) that the tool is good for with extreme ease. Unfortunately, the tool becomes unsuitable for anything else, and takes double durability damage.
 
 # -- ENCHANTMENT: QUICK DRAW
 ttresearch.name.TTENCH_QUICK_DRAW=Enchantment: Quick Draw
 ttresearch.lore.TTENCH_QUICK_DRAW=May the odds ever be in your favour
-ttresearch.page.TTENCH_QUICK_DRAW.0=You have formulated an enchantment that allows you to draw your bow in a quicker fashion.<BR><BR>This enchantment can be applied on bows. When done so, the bow can be fully drawn faster than normally.
+ttresearch.page.TTENCH_QUICK_DRAW.0=You have formulated an enchantment that allows you to draw your bow quickly.<BR><BR>This enchantment can only be applied on bows.
 
 # -- ENCHANTMENT: VAMPIRISM
 ttresearch.name.TTENCH_VAMPIRISM=Enchantment: Vampirism
 ttresearch.lore.TTENCH_VAMPIRISM=I'll take that
-ttresearch.page.TTENCH_VAMPIRISM.0=You have formulated an enchantment that allows you to drain the health of the enemies you attack.<BR><BR>This enchantment can be applied on swords. When done so, a chunk of the damage dealt to a living thing using that sword will be given back to the wielder.
+ttresearch.page.TTENCH_VAMPIRISM.0=You have formulated an enchantment that allows you to drain the health of the enemies you attack.<BR><BR>This enchantment can only be applied on swords and transfers a chunk of the damage dealt to living things using that sword to the wielder.
 
 # -- WAND FOCUS: EFREET'S FLAME
 ttresearch.name.FOCUS_SMELT=Wand Focus: Efreet's Flame
 ttresearch.lore.FOCUS_SMELT=Ribbons won't make a difference
-ttresearch.page.FOCUS_SMELT.0=By combining the flame and excavation foci, you made one that has features from both.<BR><BR>This focus will smelt any blocks in the world that the caster is pointing at, akin to the excavation focus' beam. Only blocks that smelt into other blocks in a mundane furnace will be smelted.
+ttresearch.page.FOCUS_SMELT.0=You have fashioned a focus that combines the features of the Flame and Excavation foci.<BR><BR>This focus will smelt any blocks in the world that the caster is pointing to, like the beam from the Excavation focus. Any items or blocks that cannot be smelted in a mundane furnace will remain unchanged.
 
 # -- WAND FOCUS: MENDING
 ttresearch.name.FOCUS_HEAL=Wand Focus: Mending
 ttresearch.lore.FOCUS_HEAL=Bandages, Voids and Feels
-ttresearch.page.FOCUS_HEAL.0=You know Pech carry powerful foci that can induce diseases, with that, you devised a way to use them to your benefits.<BR><BR>This focus will slowly mend the caster's wounds as they're using it, using vis from the wand in the process.
+ttresearch.page.FOCUS_HEAL.0=The Pech carry powerful foci that can induce diseases. After careful observation, you have devised a way to use their arts to your benefit.<BR><BR>This focus will slowly mend the caster's wounds when used, consuming vis stored in the wand in the process.
 
 # -- WAND FOCUS: ENDER RIFT
 ttresearch.name.FOCUS_ENDER_CHEST=Wand Focus: Ender Rift
 ttresearch.lore.FOCUS_ENDER_CHEST=A 'pocket' to the fourth dimension
-ttresearch.page.FOCUS_ENDER_CHEST.0=By combining a Hand Mirror with a portable hole, you managed to construct a focus that tears a rift in the ender, allowing you to access the contents of your Ender Chest remotely.
+ttresearch.page.FOCUS_ENDER_CHEST.0=By combining a Hand Mirror with a Portable Hole, you have managed to construct a focus that rifts through the End, giving you access to the contents of your Ender Chest remotely.
 
 # -- CURSED SPIRIT'S BLADE
 ttresearch.name.BLOOD_SWORD=Cursed Spirit's Blade
 ttresearch.lore.BLOOD_SWORD=You're being unpleasant
-ttresearch.page.BLOOD_SWORD.0=You created a sword that strikes with unparalleled force. However, for this to be the case, the sword feeds on the striker's blood.<BR><BR>Upon damaging anything with this sword, the attacker will take one heart of damage. Blocking with this sword will always deal only 1.5 hearts, regardless of the original damage.<BR><BR>Furthermore, simply holding this sword gives the holder a steadfast aura, making them move faster than normal.
+ttresearch.page.BLOOD_SWORD.0=You have created a sword that strikes with unparalleled force by feeding on the striker's blood.<BR><BR>Upon damaging anything with this sword, the attacker will take one heart of damage. Blocking with this sword will reduce all incoming damage, whatever its magnitude, to exactly 1.5 hearts.<BR><BR>Furthermore, simply holding this sword gives the holder a Steadfast aura, making them move faster than normal.
 
 # -- TRANSVECTOR DISLOCATOR
 ttresearch.name.DISLOCATOR=Transvector Dislocator
 ttresearch.lore.DISLOCATOR=No Blood Magic required
-ttresearch.page.DISLOCATOR.0=By studying motion, you managed to create a block that swaps two blocks in space.<BR><BR>This block acts like a Transvector Interface, where it must be bound to another location in space using a Transvector Binder, you can set the direction it's facing using a wand, and when a redstone signal is applied, the dislocator will swap the block in front of it with the block linked to using the binder. It also transports any and all entities in those areas.<BR><BR>It can be camouflaged similarly to the Transvector Interface. It has a longer range than it, 16 blocks.
+ttresearch.page.DISLOCATOR.0=You have gained an amazing insight into motion, fashioning a block that can swap two blocks in space.<BR><BR>Just as with a Transvector Interface, the Dislocator must be bound to another location in space with a Transvector Binder. You can set the direction the Dislocator is facing with a wand. When a redstone signal is applied, the dislocator will swap the block in front of it with the block linked to it using the Binder. It also transports any and all entities in those locations.<BR><BR>It can be camouflaged like to the Transvector Interface. It has a comparatively longer range of 16 blocks.
 
 # -- HELMET OF REVEALING
 ttresearch.name.REVEALING_HELM=Helmet of Revealing
 ttresearch.lore.REVEALING_HELM=This is why I can't use photoshop
-ttresearch.page.REVEALING_HELM.0=As it turns out, goggles don't offer much protection from attacking zombies. You think you have a fix for that though. By strapping goggles of revealing onto a thaumium helmet, you can get the benifits of both. Well, it turns out it is a bit more complicated than that. A bit of magic is required to avoid feedback loops, and a bit of magic to keep them from slipping off, but on the whole, it more or less works.
+ttresearch.page.REVEALING_HELM.0=As it turns out, goggles don't reveal the friendly side of marauding zombies. You think you have a fix for that though. By strapping the Goggles of Revealing onto a Thaumium Helmet, surely you gain the benefits of both! Well... it is a bit more complicated than that. A bit of magic is required to avoid feedback loops, and a bit more magic to keep them from slipping off, but on the whole, the idea is basically sound.
 
 # -- THAUMIC REHABILITATOR
 ttresearch.name.REPAIRER=Thaumic Restorer
-ttresearch.lore.REPAIRER=Less cracks than a potato on a stick
-ttresearch.page.REPAIRER.0=You created a new contraption to restore broken tools. By right clicking this block with a broken tool and hooking it to essentia tubes, it'll gather essentia to repair the tool.<BR><BR>The essentia that will repair, in order of least to most effective are Ordo, Fabrico and Instrumentum.<BR><BR>Looking at the block with goggles of revealing also shows how worn down the item in it still is.
+ttresearch.lore.REPAIRER=Fewer cracks than a potato on a stick
+ttresearch.page.REPAIRER.0=You have fashioned a new gizmo to restore broken tools. By right clicking this block with a broken tool and hooking it to essentia tubes, it gathers essentia to repair the tool.<BR><BR>The essentia that can perform repairs, in order of least to most effective, are Ordo, Fabrico and Instrumentum.<BR><BR>Looking at the block with the Goggles of Revealing also shows the current condition of the item in the Restorer.
 
 # -- WAND FOCUS: DISTORTION
 ttresearch.name.FOCUS_DEFLECT=Wand Focus: Distortion
 ttresearch.lore.FOCUS_DEFLECT=I'm not an Angel
-ttresearch.page.FOCUS_DEFLECT.0=You created a focus to protect you from incoming fire.<BR><BR>This focus, when in use, will constantly drain vis from the wand it's inserted on, in order to summon a ward around the caster, making ordinary projectiles pass through them harmlessly.<BR><BR>Ordinary projectiles include arrows, snowballs or potions. It seems the ward is not strong enough to displace stronger attacks, like fireballs or wither heads.
+ttresearch.page.FOCUS_DEFLECT.0=You have created a focus to protect you from missiles.<BR><BR>This focus, when in use, will summon a ward around the caster that makes ordinary projectiles pass through them harmlessly. The focus will constantly drain vis from its wand.<BR><BR>Ordinary projectiles include arrows, snowballs or potions. It seems the ward is not strong enough to displace stronger projectiles like fireballs or wither heads.
 
-# -- ETHERAL PLATFORM
+# -- ETHEREAL PLATFORM
 ttresearch.name.PLATFORM=Ethereal Platform
 ttresearch.lore.PLATFORM=Hide the Bromine and Barium
-ttresearch.page.PLATFORM.0=You devised a block that is only solid for anyone standing on top of it. This block does not have a collision box for anyone who doesn't meet that criteria, or is sneaking.<BR><BR>You can also camouflage this block as any other by simply clicking on it.<BR><BR>You think you can use this with the Arcane Levitator for some interesting effects.
+ttresearch.page.PLATFORM.0=You have devised a block that is only solid for anyone standing on top of it. This block does not have a collision box for anyone who doesn't meet that criteria, or is sneaking.<BR><BR>You can also camouflage this block as any other by simply clicking on it.<BR><BR>Your mind races with the possibilities. That Arcane Levitator over there certainly looks interesting...
 
 # KAMI RESEARCH
 
 # -- DIMENSIONAL SHARDS
 ttresearch.name.DIMENSION_SHARDS=Dimensional Shards
 ttresearch.lore.DIMENSION_SHARDS=Rarities of the Otherworld
-ttresearch.page.DIMENSION_SHARDS.0=Similarly to the overworld, the Nether and the End also have their specific shards, these are rarely held by either Zombie Pigmen living in the Nether or Endermen living in the End. They might be useful for something later on, although you're not quite sure how.<BR><BR><IMG>ttinkerer:textures/items/netherShard.png:0:0:255:255:0.0625</IMG><IMG>ttinkerer:textures/items/enderShard.png:0:0:255:255:0.0625</IMG>
+ttresearch.page.DIMENSION_SHARDS.0=Like the Overworld, the Nether and the End have their specific shards. These are rarely held by either Zombie Pigmen in the Nether or Endermen in the End. They may be useful for something later on, although you're not quite sure how.<BR><BR><IMG>ttinkerer:textures/items/netherShard.png:0:0:255:255:0.0625</IMG><IMG>ttinkerer:textures/items/enderShard.png:0:0:255:255:0.0625</IMG>
 
 # -- ICHOR
 ttresearch.name.ICHOR=Ichor
 ttresearch.lore.ICHOR=Blood of the Gods
-ttresearch.page.ICHOR.0=Through extensive study in all subjects of thaumaturgy you have discovered a substance that is what you consider to be the next step in your endeavours.<BR><BR>This extremely powerful substance, which you call "Ichor" contains the raw awakened power of a nether star. You are sure you will be able to put it to use for countless devices in the future.
+ttresearch.page.ICHOR.0=Through extensive study in all subjects of thaumaturgy you are now ready to take the next step.<BR><BR>You have discovered an extremely powerful substance, which you call "Ichor", that contains the raw awakened power of a Nether Star. You are excited about the possible uses for this fascinating substance.
 
 # -- ICHORCLOTH
 ttresearch.name.ICHOR_CLOTH=Ichorcloth
-ttresearch.lore.ICHOR_CLOTH=Life Fiber Sychronization
-ttresearch.page.ICHOR_CLOTH.0=You found a way of infusing Magical Fabric with your latest discovery, Ichor. Funilly enough, this process does not require the typical infusion procedure, as the Ichor easilly absorbs the diamond and blends with the fabric.<BR><BR>However, to do this, you require not only the best wand you ever designed to be fully charged, but you must also be wearing a full set of thaumaturge's robes, in order to convey enough energy for the creation.<BR><BR>You think it's time you start designing a new wand.
+ttresearch.lore.ICHOR_CLOTH=Life Fiber Synchronization
+ttresearch.page.ICHOR_CLOTH.0=You have found a way of infusing Magical Fabric with your latest discovery, Ichor. Funnily enough, this process does not require the typical infusion procedure, as the Ichor easily absorbs the diamond and blends with the fabric.<BR><BR>However, you require not only the best wand you ever designed, fully charged, but you also must be wearing a full set of Thaumaturgist Robes in order to convey enough energy into the creation.<BR><BR>Clearly, it's time you start designing a new wand...
 
 # -- ICHORIUM
 ttresearch.name.ICHORIUM=Ichorium
 ttresearch.lore.ICHORIUM=Not from the 55th floor
-ttresearch.page.ICHORIUM.0=More endeavours with Ichor reveal it's property to blend with most mundane materials. Most of the blends result in absolutely nothing, however, you have managed to blend it with diamonds and fabric in the past, and this time, with thaumium.<BR><BR>This metal is extremely strong and resillient, to a point where mundane materials could never get. You haven't found any uses for it yet, but you know it shouldn't take you too long.
+ttresearch.page.ICHORIUM.0=You hav already seen that Ichor blends with most mundane materials. Most of the blends result in absolutely nothing, although you have had some limited success with diamonds and fabric. Thaumium though... Ichor takes to thaumium like nothing you've ever seen before.<BR><BR>The alloys is so strong and resilient that no mundane material can make the barest scratch upon it. This substance, which you call Ichorium, will revolutionize everything if you can just figure out how to mould it...
 
 # -- ICHORCLOTH STRAPPED SILVERWOOD WAND CORE
 ttresearch.name.ICHORCLOTH_ROD=Ichorcloth Strapped Silverwood Wand Core
 ttresearch.lore.ICHORCLOTH_ROD=That's a mouthful
-ttresearch.page.ICHORCLOTH_ROD.0=You have done it. By infusing a silverwood wand core with Ichorcloth, you managed to create the ultimate wand core.<BR><BR>This core holds an insane amount of 1000 of each type of vis. This will definitely make crafting expensive components a bit less stressful. Now the question lies, where will you get all the vis for this?
+ttresearch.page.ICHORCLOTH_ROD.0=You've done it! By infusing a Silverwood wand core with Ichorcloth, you have created the ultimate wand core.<BR><BR>This core holds an insane amount (1000) of each type of vis. This will definitely make crafting expensive components a bit less stressful. But where will you find all that vis?
 
 # -- ICHORIUM WAND CAPS
 ttresearch.name.ICHOR_CAP=Ichorium Wand Caps
 ttresearch.lore.ICHOR_CAP=Somewhat like a Steam Sale
-ttresearch.page.ICHOR_CAP.0=You have put Ichorium to it's first ever use, by devising wand caps that give you a 20% discount on everything. Now you need to actually put this to any use and create a wand that can store more vis.
+ttresearch.page.ICHOR_CAP.0=A-ha! Wand Caps! Your new Ichorium Wand Caps appear to give you a 20% discount on everything. All that's left is to combine it with the best core and make a tidy vis profit.
 
 # -- ICHORCLOTH ARMOR
-ttresearch.name.ICHORCLOTH_ARMOR=Ichorcloth Robes
+ttresearch.name.ICHORCLOTH_ARMOR=Ichorcloth Armor
 ttresearch.lore.ICHORCLOTH_ARMOR=Kamui Senk... wait
-ttresearch.page.ICHORCLOTH_ARMOR.0=You have found how to weave ichorcloth into clothing.<BR><BR>These new clothes are about as effective as mundane diamond armor, when it comes to protecting the wearer from damage. However, this cloth is completely umbreakable and will never sustain as much as a scratch.
+ttresearch.page.ICHORCLOTH_ARMOR.0=You have woven Ichorcloth into clothing.<BR><BR>These new clothes are about as effective as mundane diamond armor when it comes to protecting the wearer from damage. However, this cloth is completely unbreakable and will never sustain as much as a scratch.
 
 # -- COWL OF THE ABYSSAL DEPTHS
 ttresearch.name.ICHORCLOTH_HELM_GEM=Cowl of the Abyssal Depths
 ttresearch.lore.ICHORCLOTH_HELM_GEM=Just friendly crustaceans
-ttresearch.page.ICHORCLOTH_HELM_GEM.0=You found a way of upgrading the Ichorcloth Cowl into a more powerful form.<BR><BR>First and foremost, the cowl doubles as goggles of revealing.<BR>Second, the wearer is granted unlimited underwater breath as well as crystal clear underwater vision.<BR>Lastly, if one wearing this cowl finds themselves without a full belly, the effects of health restoration will still apply, as if that was the case.
+ttresearch.page.ICHORCLOTH_HELM_GEM.0=You have tweaked the Ichorcloth Cowl into something more powerful.<BR><BR>First and foremost, it reveals secrets just as a Goggles of Revealing.<BR>Second, the Cowl grants unlimited breath as well as crystal clear underwater vision.<BR>Lastly, health regenerates constantly as if the wearer had just gorged on steak and pumpkin pie, regardless of the actual level of hunger.
 
 # -- ROBES OF THE STRATOSPHERE
 ttresearch.name.ICHORCLOTH_CHEST_GEM=Robes of the Stratosphere
 ttresearch.lore.ICHORCLOTH_CHEST_GEM=Guys can wear these too
-ttresearch.page.ICHORCLOTH_CHEST_GEM.0=You found a way of upgrading the Ichorcloth Robes into a more powerful form.<BR><BR>Starting off, by simply wearing these robes, the wearer is blessed with the power of eternal flight (wings that don't burn after 5 minutes included), as well as having all fall damage negated.<BR>The robes also passively protect the wearer from any incoming simple projectiles, akin to the focus of Distortion.
+ttresearch.page.ICHORCLOTH_CHEST_GEM.0=You have added a number of upgrades to the Ichorcloth Robes.<BR><BR>By simply wearing these robes, the wearer is blessed with the power of eternal flight (wings that don't burn after 5 minutes included), and all fall damage is negated.<BR>The robes also passively protect the wearer from any incoming simple projectiles, akin to the Focus of Distortion.
 
 # -- LEGGINGS OF THE BURNING MANTLE
 ttresearch.name.ICHORCLOTH_LEGS_GEM=Leggings of the Burning Mantle
 ttresearch.lore.ICHORCLOTH_LEGS_GEM=A warm feeling
-ttresearch.page.ICHORCLOTH_LEGS_GEM.0=You found a way of upgrading the Ichorcloth Leggings into a more powerful form.<BR><BR>These leggings are infused with the soul of fire.<BR>For one, they cast a light around the holder, brighter even than that of Hyperenergetic Nitor. This light also expands to where the wearer is looking, akin to a flashlight, and prevales given the creator's existance in a much extended range.<BR>Furthermore, these leggings not only provide fire resistance, but they convert any incoming fire damage into healing.
+ttresearch.page.ICHORCLOTH_LEGS_GEM.0=You have added a number of upgrades to the Ichorcloth Leggings.<BR><BR>These leggings are infused with the soul of fire.<BR>They cast a light around the holder, brighter even than Hyperenergetic Nitor. This light also expands to where the wearer is looking, like a flashlight, and has a greatly extended range.<BR>Furthermore, these leggings not only provide fire resistance, but also convert any incoming fire damage into healing.
 
 # -- BOOTS OF THE HORIZONTAL SHIELD
 ttresearch.name.ICHORCLOTH_BOOTS_GEM=Boots of the Horizontal Shield
 ttresearch.lore.ICHORCLOTH_BOOTS_GEM=From Winterfell to King's Landing in a breeze
-ttresearch.page.ICHORCLOTH_BOOTS_GEM.0=You found a way of upgrading the Ichorcloth Boots into a more powerful form.<BR><BR>These boots allow for extremely smooth movement, akin to the Boots of the Traveller. The wearer's speed, jump height and jump reach all become magnified by wearing the boots, making movement a breeze. One can also walk on 1 high blocks as if they are slabs, this can be suppressed by sneaking.<BR>Wearing the boots also induces a constant Haste II effect, turns any dirt below them into grass and negates all fall damage.
+ttresearch.page.ICHORCLOTH_BOOTS_GEM.0=You have added a number of upgrades to the Ichorcloth Boots.<BR><BR>These boots allow for extremely smooth movement, reminiscent of the Boots of the Traveller. The wearer's speed, jump height and jump reach all become magnified. The wearer can also climb whole blocks as if they were slabs (this can be suppressed by sneaking).<BR>Wearing the boots also induces a constant Haste II effect, turns trodden dirt into grass, and negates all fall damage.
 
 # -- FELINE AMULET
 ttresearch.name.CAT_AMULET=Feline Amulet
 ttresearch.lore.CAT_AMULET=No fighting with cats in the cafeteria
-ttresearch.page.CAT_AMULET.0=It didn't take you long to come to the conclusion that you hated all those times a creeper snuck up on you.<BR><BR>To that end, using the knowledge you have that creepers run away from cats, you have devised an amulet that by simply being carried on you makes all creepers run in fear of your presence. Not only that, but they'll be petrified to the point of not gathering enough stoke to explode. Great.
+ttresearch.page.CAT_AMULET.0=If you hear another creeper sneak up on you, it will be one time too many!<BR><BR>After observing your cat, you have discovered how it repels creepers. You distill this knowledge into an amulet whose mere presence in your inventory makes all creepers run in fear. Those creepers that cannot run away are petrified and do not explode. Time for some sweet revenge...
 
 # -- ICHORIUM TOOLS
 ttresearch.name.ICHOR_TOOLS=Ichorium Tools
 ttresearch.lore.ICHOR_TOOLS=The top tier of rat... tools
-ttresearch.page.ICHOR_TOOLS.0=You discovered how to create tools out of Ichorium. These tools are extremely powerful, even more so than diamond, furthermore, they never break.<BR><BR>For the creation of these tools, mundane sticks aren't enough, you decided to use Silverwood rods in replacement.
+ttresearch.page.ICHOR_TOOLS.0=At long last you have figured out how to fashion tools out of Ichorium. These tools are extremely powerful, stronger by far than diamond. They never break!<BR><BR>Mundane tool rods do not suffice for such powerful tools: you need Silverwood rods.
 
 # -- AWAKENED ICHORIUM PICKAXE
 ttresearch.name.ICHOR_PICK_GEM=Awakened Ichorium Pickaxe
 ttresearch.lore.ICHOR_PICK_GEM=Who needs a quarry?
-ttresearch.page.ICHOR_PICK_GEM.0=You awakened the real potential of an Ichorium Pickaxe, this pickaxe contains all the traits from the regular one, however, by right clicking on it, you can change what mode it's on.<BR><BR>On Block Mode (Green) it'll break blocks normally.<BR><BR>On Square Mode (Red) it'll break a 5x5 area around the original block broken.<BR><BR>On Line Mode (Blue) it'll break a 10 block long line starting on the original block.
+ttresearch.page.ICHOR_PICK_GEM.0=You have unlocked the real potential of the Ichorium Pickaxe. This awakened pickaxe inherits all the traits from the dormant one, but right clicking with it changes its mode.<BR><BR>In Block Mode (Green) it breaks blocks normally.<BR><BR>In Square Mode (Red) it breaks a 5x5 area around the mined block.<BR><BR>In Line Mode (Blue) it breaks a 10 block long line starting from the mined block.
 
 # -- AWAKENED ICHORIUM SHOVEL
 ttresearch.name.ICHOR_SHOVEL_GEM=Awakened Ichorium Shovel
 ttresearch.lore.ICHOR_SHOVEL_GEM=Gravel no more!
-ttresearch.page.ICHOR_SHOVEL_GEM.0=You awakened the real potential of an Ichorium Shovel, this shovel contains all the traits from the regular one, however, by right clicking on it, you can change what mode it's on.<BR><BR>On Block Mode (Green) it'll break blocks normally.<BR><BR>On Square Mode (Red) it'll break a 5x5 area around the original block broken.<BR><BR>On Column Mode (Blue) it'll break a column of the same type of block as the one originally broken, 8 blocks above and below.
+ttresearch.page.ICHOR_SHOVEL_GEM.0=You have unlocked the true potential of the Ichorium Shovel. This awakened shovel inherits all the traits of the dormant one, but right clicking with it changes its mode.<BR><BR>In Block Mode (Green) it breaks blocks normally.<BR><BR>In Square Mode (Red) it breaks a 5x5 area around the mined block.<BR><BR>In Column Mode (Blue) it breaks a column of the same type of block as the one mined, up to 8 blocks above and below.
 
 # -- AWAKENED ICHORIUM AXE
 ttresearch.name.ICHOR_AXE_GEM=Awakened Ichorium Axe
 ttresearch.lore.ICHOR_AXE_GEM=Cut you like a Clover
-ttresearch.page.ICHOR_AXE_GEM.0=You awakened the real potential of an Ichorium Axe, this axe contains all the traits from the regular one, however, by right clicking on it, you can change what mode it's on.<BR><BR>On Block Mode (Green) it'll break blocks normally.<BR><BR>On Square Mode (Red) it'll break a 5x5 area around the original block broken.<BR><BR>On Tree Mode (Blue) it'll break entire trees by simply cutting down one of their blocks.<BR><BR>This axe is also extremely proficient at cutting plant life.
+ttresearch.page.ICHOR_AXE_GEM.0=You have unlocked the true potential of the Ichorium Axe. This awakened axe inherits all the traits of the dormant one, but right clicking with it changes its mode.<BR><BR>In Block Mode (Green) it breaks blocks normally.<BR><BR>In Square Mode (Red) it breaks a 5x5 area around the mined block.<BR><BR>In Tree Mode (Blue) it cuts down entire trees by simply any of its blocks is mined.<BR><BR>This axe is also extremely proficient at cutting plants.
 
 # -- AWAKENED ICHORIUM SWORD
 ttresearch.name.ICHOR_SWORD_GEM=Awakened Ichorium Sword
 ttresearch.lore.ICHOR_SWORD_GEM=Mom's knife
-ttresearch.page.ICHOR_SWORD_GEM.0=You awakened the real potential of an Ichorium Sword, this sword contains all the traits from the regular one, however, by shift right clicking on it, you can change what mode it's on.<BR><BR>On Single Mode (Green) it'll attack mobs normally.<BR><BR>On Area Mode (Red) it'll attack all mobs of the same type in a 3 block radius of the attacked one.<BR><BR>On Soul Mode (Blue) it'll deal less damage than normally, but every hit will bless the attacker with a Soul Heart.<BR>[continued]
-ttresearch.page.ICHOR_SWORD_GEM.1=Soul Hearts are hearts that can only be used once. They show up as metallic hearts below your food bar, when existant. They block damage their wielder would take, but disappear in the proccess.
+ttresearch.page.ICHOR_SWORD_GEM.0=You have unlocked the true potential of the Ichorium Sword. This awakened sword inherits all the traits from the dormant one, but right clicking with it changes its mode.<BR><BR>In Single Mode (Green) it attacks mobs normally.<BR><BR>In Area Mode (Red) it attacks all mobs of the same type in a 3 block radius of the attacked mob.<BR><BR>In Soul Mode (Blue) it deal less damage, but every hit will bless the attacker with a Soul Heart.<BR>[continued]
+ttresearch.page.ICHOR_SWORD_GEM.1=Soul Hearts are hearts that can only be used once. (They show up as metallic hearts below your food bar.) They block damage their wielder would take, but disappear in the process.
 
 # -- BOTTOMLESS POUCH
 ttresearch.name.ICHOR_POUCH=Bottomless Pouch
 ttresearch.lore.ICHOR_POUCH=Haha, he said bottom
-ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you managed to allow it to not only store more than Foci, but also to have a very extensive storage space.<BR><BR>This pouch can not only carry more than four chests, but it also doubles as a standard Focus Pouch, allowing any foci within it to be inserted in a wand like normally. You can kiss your inventory problems goodbye.
+ttresearch.page.ICHOR_POUCH.0=By infusing a Focus Pouch with items such as the Portable Hole focus, you have managed to allow it to not only store all items, but also to have an immense storage space.<BR><BR>This pouch can not only carry more than four chests worth of items. It also doubles as a standard Focus Pouch, allowing any foci within it to be inserted in a wand like normally. You are a walking warehouse.
 
 # -- BLACK HOLE TALISMAN
 ttresearch.name.BLOCK_TALISMAN=Black Hole Talisman
 ttresearch.lore.BLOCK_TALISMAN=More pascal than your mind can take
-ttresearch.page.BLOCK_TALISMAN.0=This talisman can be set to condense any block, by right clicking with it in world in the type of block you want to have it be set to, when enabled via right click will absorb any excess (over 1 stack) of that block in your inventory, and make sure at least one stack stays there. The contents can be stored in any inventory by right clicking it, or placed in world as if they were normal blocks.<BR><BR>It can store over 2 billion of the same block. Guess cobblestone clogging the space isn't an issue. If the talisman is empty, it can be shift right clicked into another block to change it's binding.
+ttresearch.page.BLOCK_TALISMAN.0=You have devised a talisman that can condense any type of block. Right click on a block in the world with it, and it will absorb any excess (over 1 stack) of that block in your inventory, leaving at least one stack untouched. The contents of the talisman can be placed into any inventory by right clicking it, or placed in the world as normal blocks.<BR><BR>It can store over two billion of one type of block. You finally have every block of cobblestone you've ever mined right at your fingertips.<BR>Right clicking a block with an empty talisman while sneaking changes its binding to that block.
 
 # -- WORLDSHAPER'S LOOKING GLASS
 ttresearch.name.PLACEMENT_MIRROR=Worldshaper's Looking Glass
 ttresearch.lore.PLACEMENT_MIRROR=Eye of Mercury
-ttresearch.page.PLACEMENT_MIRROR.0=Through studying the world, you constructed a glass that allows you place a large array of blocks in the world using the power of your mind.<BR><BR>To set a block to place, one would shift-right click this glass in that block. Shift-right clicking the item in the air changes the amount of blocks it'll place.<BR><BR>When placing blocks in the world, a phantom visualization of how the blocks will appear is shown. On right click, the blocks will be consumed and placed, either from the inventory, or any Black Hole Talismans that contain the required block.
+ttresearch.page.PLACEMENT_MIRROR.0=The novice thaumaturge places blocks with their hands; the master places blocks with their mind.<BR><BR>Right click the Looking Glass on a block to set its block type. Right click in the air while sneaking to determine the number and configuration of the selected block to place.<BR>Right clicking will place the blocks from your inventory or any Black Hole Talismans containing that selected block.<BR>Phantom blocks appear in the world to show where the blocks would be placed.


### PR DESCRIPTION
- Consistently changed the tense of research notes from past tense to
  past perfect tense to be in line with Thaumcraft notes
- Even though this says en_US, it uses a number of British spellings
  (e.g., mould, colour, labour). I've left them in, uncorrected. Words
  like "analyze", "armor", etc. are correctly en_US, however.
- Made some minor tweaks to the flavor text to make it less bland.
- Changed "of Withhold" to "of Withholding". Corrected "desintigrate"
  to "disintigrate". These are the only changes to item names.

Take all of it as suggestions.
