### PR TITLE
Don't block player's own projectiles (closes Vazkii/ThaumicTinkerer#201)

### DIFF
--- a/src/main/java/vazkii/tinkerer/common/core/helper/ProjectileHelper.java
+++ b/src/main/java/vazkii/tinkerer/common/core/helper/ProjectileHelper.java
@@ -1,0 +1,64 @@
+package vazkii.tinkerer.common.core.helper;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import com.google.common.base.Function;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.EntityArrow;
+import net.minecraft.entity.projectile.EntityThrowable;
+import thaumcraft.common.entities.projectile.EntityFrostShard;
+
+public final class ProjectileHelper {
+	private static Map<Class<? extends Entity>, Function<Entity, Entity>> ownerGetters =
+			new IdentityHashMap<Class<? extends Entity>, Function<Entity, Entity>>();
+
+	public static Entity getOwner(Entity projectile) {
+		Function<Entity, Entity> ownerGetterForClass = ownerGetters.get(projectile.getClass());
+		if(ownerGetterForClass != null) {
+			return ownerGetterForClass.apply(projectile);
+		}
+
+		// Check if we have owner getter for any of the superclasses
+		for(Map.Entry<Class<? extends Entity>, Function<Entity, Entity>> ownerGetter : ownerGetters.entrySet()) {
+			if(ownerGetter.getKey().isAssignableFrom(projectile.getClass())) {
+				return ownerGetter.getValue().apply(projectile);
+			}
+		}
+
+		return null;
+	}
+
+	public static void registerOwnerGetter(Class<? extends Entity> projectileClass, Function<Entity, Entity> ownerGetter) {
+		ownerGetters.put(projectileClass, ownerGetter);
+	}
+
+	/* Owner getters for vanilla Minecraft and Thaumcraft projectiles */
+	public static class VanillaArrowOwnerGetter implements Function<Entity, Entity> {
+		@Override
+		public Entity apply(Entity e) {
+			return ((EntityArrow)e).shootingEntity;
+		}
+	}
+
+	public static class VanillaThrowableOwnerGetter implements Function<Entity, Entity> {
+		@Override
+		public Entity apply(Entity e) {
+			return ((EntityThrowable)e).getThrower();
+		}
+	}
+
+	public static class ThaumcraftFrostShardOwnerGetter implements Function<Entity, Entity> {
+		@Override
+		public Entity apply(Entity e) {
+			Entity owner = ((EntityFrostShard)e).shootingEntity;
+			return owner != null ? owner : e.worldObj.getEntityByID(((EntityFrostShard)e).shootingEntityId);
+		}
+	}
+
+	static {
+		registerOwnerGetter(EntityArrow.class, new VanillaArrowOwnerGetter());
+		registerOwnerGetter(EntityThrowable.class, new VanillaThrowableOwnerGetter());
+		registerOwnerGetter(EntityFrostShard.class, new ThaumcraftFrostShardOwnerGetter());
+	}
+}

--- a/src/main/java/vazkii/tinkerer/common/item/foci/ItemFocusDeflect.java
+++ b/src/main/java/vazkii/tinkerer/common/item/foci/ItemFocusDeflect.java
@@ -27,6 +27,7 @@ import thaumcraft.client.codechicken.core.vec.Vector3;
 import thaumcraft.common.config.Config;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import vazkii.tinkerer.common.ThaumicTinkerer;
+import vazkii.tinkerer.common.core.helper.ProjectileHelper;
 
 public class ItemFocusDeflect extends ItemModFocus {
 
@@ -48,6 +49,8 @@ public class ItemFocusDeflect extends ItemModFocus {
 		List<Entity> projectiles = p.worldObj.getEntitiesWithinAABB(IProjectile.class, AxisAlignedBB.getBoundingBox(p.posX - 4, p.posY - 4, p.posZ - 4, p.posX + 3, p.posY + 3, p.posZ + 3));
 
 		for(Entity e : projectiles) {
+			if(ProjectileHelper.getOwner(e) == p) continue;
+
 			Vector3 motionVec = new Vector3(e.motionX, e.motionY, e.motionZ).normalize().multiply(Math.sqrt((e.posX - p.posX) * (e.posX - p.posX) + (e.posY - p.posY) * (e.posY - p.posY) + (e.posZ - p.posZ) * (e.posZ - p.posZ)) * 2) ;
 
 			for(int i = 0; i < 6; i++)


### PR DESCRIPTION
I attempted to make this in a way to make it easy to add projectiles from other mods. It should be possible to add ability for mods to register their projectiles using IMC providing projectile class name and owner getter class name without having to reference any of TT classes, if any wish to.
