### PR TITLE
Delete build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,0 @@
-ant build
-pause


### PR DESCRIPTION
This file contains outdated build instructions (see issue #435)
