### PR TITLE
Fixed Ichor wand and kami configuration check.

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/core/handler/ModCreativeTab.java
+++ b/src/main/java/thaumic/tinkerer/common/core/handler/ModCreativeTab.java
@@ -41,7 +41,7 @@ public class ModCreativeTab extends CreativeTabs {
 
     public ModCreativeTab() {
         super(LibMisc.MOD_ID);
-        addWand();
+        //addWand();
     }
 
     @Override
@@ -62,7 +62,7 @@ public class ModCreativeTab extends CreativeTabs {
 
     }
 
-    private void addWand() {
+    public void addWand() {
         ItemStack wand = new ItemStack(ConfigItems.itemWandCasting);
         ((ItemWandCasting) wand.getItem()).setRod(wand, ConfigItems.WAND_ROD_SILVERWOOD);
         ((ItemWandCasting) wand.getItem()).setCap(wand, ConfigItems.WAND_CAP_THAUMIUM);

--- a/src/main/java/thaumic/tinkerer/common/core/proxy/TTCommonProxy.java
+++ b/src/main/java/thaumic/tinkerer/common/core/proxy/TTCommonProxy.java
@@ -84,6 +84,9 @@ public class TTCommonProxy {
         ThaumicTinkerer.registry.preInit();
         capIchor = new CapIchor();
         rodIchor = new RodIchorcloth();
+        
+        ModCreativeTab.INSTANCE.addWand();
+        
         if (Loader.isModLoaded("ComputerCraft")) {
             initCCPeripherals();
         }


### PR DESCRIPTION
The creative tab was created before the configuration file read, so kami was always disabled for the creative tab. Shit happens.