### PR TITLE
Fix for #717 (fire damage mitigation/healing) and #638 (harmless Botania projectile deflection, and many others)

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDeflect.java
+++ b/src/main/java/thaumic/tinkerer/common/item/foci/ItemFocusDeflect.java
@@ -63,9 +63,45 @@ public class ItemFocusDeflect extends ItemModFocus {
     public static void protectFromProjectiles(EntityPlayer p) {
         List<Entity> projectiles = p.worldObj.getEntitiesWithinAABB(IProjectile.class, AxisAlignedBB.getBoundingBox(p.posX - 4, p.posY - 4, p.posZ - 4, p.posX + 3, p.posY + 3, p.posZ + 3));
 
+	// only deflect projectiles if the player is within a set angle in front of their trajectory
+	// this angle will scale inversely with distance - narrow angles at long range, wider angles at close range
+	// we define an exclusion zone around the player as 1.5x the maximum radius (core to corner)
+	// and from this exclusion zone, we derive the distance-dependent angle
+	
+	// due to things like Morph, we'll need to calculate the exclusion zone instead of using a static value
+	// calculation is done outside of the projectile checking loop to avoid repeated computations of the same value
+	double safe_exclusion_zone = 1.5F * Math.sqrt((p.height * p.height * 0.25F) + (p.width * p.width * 0.25F));
+	double safe_exclusion_zone_sq = safe_exclusion_zone * safe_exclusion_zone;
+
         for (Entity e : projectiles) {
             if (CheckBlackList(e) || ProjectileHelper.getOwner(e) == p)
                 continue;
+
+	    Vector3 entPos = new Vector3(p.posX, p.posY + p.height * 0.5F, p.posZ);
+	    Vector3 projPos = new Vector3(e.posX, e.posY, e.posZ);
+	    Vector3 projVel = new Vector3(e.motionX, e.motionY, e.motionZ);
+	    
+	    Vector3 separation = entPos.subtract(projPos);
+	    double distance = separation.mag();
+	    double cosine = separation.normalize().dotProduct(projVel.normalize());
+	    
+	    double comparison = distance / Math.sqrt(distance * distance + safe_exclusion_zone_sq);
+	    
+	    // 0.707 = sqrt(2) = cos(45 degrees) - the detection angle won't go any higher than this
+	    // the angle cap is what prevents your own (outgoing) projectiles from being affected
+	    // for incoming projectiles already in flight, this is not an issue
+	    // but anything which is actively fired from inside the exclusion zone will hit (tested with arrows in a dispenser)
+	    // I don't consider this a problem, because you are now well within melee range
+	    if(comparison < 0.707) {
+	        comparison = 0.707;
+	    }
+	    
+	    // if the target is not within a cone of semi-angle acos(comparison) from the projectile's velocity vector
+	    // then we don't consider it a threat, hence we won't deflect it
+	    if(cosine < comparison) {
+	        continue;
+	    }
+
             Vector3 motionVec = new Vector3(e.motionX, e.motionY, e.motionZ).normalize().multiply(Math.sqrt((e.posX - p.posX) * (e.posX - p.posX) + (e.posY - p.posY) * (e.posY - p.posY) + (e.posZ - p.posZ) * (e.posZ - p.posZ)) * 2);
 
             for (int i = 0; i < 6; i++)

--- a/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
+++ b/src/main/java/thaumic/tinkerer/common/item/kami/armor/ItemGemLegs.java
@@ -19,10 +19,8 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.potion.Potion;
-import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.MathHelper;
-import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.research.ResearchPage;
@@ -57,12 +55,7 @@ public class ItemGemLegs extends ItemIchorclothArmorAdv {
         ItemStack armor = player.getCurrentArmor(1);
         if (armor.getItemDamage() == 1 || !ThaumicTinkerer.proxy.armorStatus(player))
             return;
-        PotionEffect effect=player.getActivePotionEffect(Potion.fireResistance);
-        if (effect != null && effect.duration <= 202)
-            effect.duration = 202;
-        else
-            player.addPotionEffect(new PotionEffect(Potion.fireResistance.id,
-                    202, 10, true));
+
         ItemBrightNitor.meta = 1;
         ((ItemBrightNitor)ThaumicTinkerer.registry.getFirstItemFromClass(ItemBrightNitor.class)).onUpdate(null, player.worldObj, player, 0, false);
         ItemBrightNitor.meta = 0;
@@ -104,7 +97,7 @@ public class ItemGemLegs extends ItemIchorclothArmorAdv {
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
-    public void onDamageTaken(LivingHurtEvent event) {
+    public void onDamageTaken(LivingAttackEvent event) {
         if (event.entityLiving instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) event.entityLiving;
             if (player.getCurrentArmor(1) != null && player.getCurrentArmor(1).getItem() == this && event.source.isFireDamage() && ThaumicTinkerer.proxy.armorStatus(player)) {


### PR DESCRIPTION
There are 2 changes in here which I previously coded for a 1.6 build, but never got around to implementing.

Firstly is a tweak to the Leggings of the Burning Mantle (for issue #717). The Fire Resistance potion effectively hooks the LivingAttackEvent and then cancels it - which is what prevents the LivingHurtEvent from ever firing and hence healing the player. I've removed the fire resist potion and changed the event hook to the LivingAttackEvent. When this event is cancelled, it also nullifies the knockback effect (which I think was the original reason for switching to a fire resist potion), something which has already happened when the LivingHurtEvent is fired.

Secondly is a change to the way in which the deflection focus/Robes of the Stratosphere works (for issue #638 and many, many others). Basically, it now only erases projectiles which are heading towards the player and which will intersect a ~1.5 metre radius sphere centred on the player (the exact distance depends on the player dimensions, so there should be some level of compatibility with Morph and other such mods). Outbound projectiles will not be deflected, so you can fire any weapon (bows, Xeno's Reliquary handguns, MFR needleguns, etc.) or stand on a battery of arrow-shooting dispensers as long as you aren't running forward faster than the projectile speed. Neither will projectiles on an oblique path - while this doesn't stop you from directly blocking Botania mana bursts (yes, I know that they're whitelisted), you won't disrupt your entire setup simply by wearing the armour and standing in the same room.

The only drawback is that projectiles fired at you from inside the exclusion zone aren't reliably deflected, but you're well within melee range at this point so I don't consider it to be a critical flaw.
