### PR TITLE
Update to address issue #860, negative value in Random.nextInt()

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -40,7 +40,7 @@ public class AspectCropLootManager {
         }
 
         Random rand = new Random();
-        int randInt = rand.nextInt(sum);
+        int randInt = rand.nextInt(Math.abs(sum));
         for (Map.Entry<ItemStack, Integer> pair : aspectHashmap.entrySet()) {
             randInt -= pair.getValue();
             if (randInt <= 0) {


### PR DESCRIPTION
Use absolute value of sum in Random.nextInt to prevent java.lang.IllegalArgumentException: bound must be positive.