### PR TITLE
Infinite loop problem from Bedrock Dimension in SkyBlock.

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/block/kami/BlockBedrockPortal.java
+++ b/src/main/java/thaumic/tinkerer/common/block/kami/BlockBedrockPortal.java
@@ -152,6 +152,12 @@ public class BlockBedrockPortal extends BlockMod {
 
                 while (entity.worldObj.getBlock(x, y, z) == Blocks.air || entity.worldObj.getBlock(x, y, z).isAir(par1World, x, y, z)) {
                     y--;
+                    // Avoid infinite loop.
+                    if (y <= 1) {
+                        y = 120;
+                        // Set up the scaffolding.
+                        entity.worldObj.setBlock(x, y - 1, z, Blocks.stone);
+                    }
                 }
 
                 ((EntityPlayerMP) entity).playerNetServerHandler.setPlayerLocation(x + 0.5, y + 3, z + 0.5, 0, 0);


### PR DESCRIPTION
In **SkyBlock** environment, such as FTB Infinity Evolved Skyblock, **permanent timed out** occurs when returning from Bedrock Dimension.
![Timed out](https://i.gyazo.com/9146c6c40824913a4f2d9cd53b02e2e5.png)

As I saw the source code, I found that it was falling into an infinite loop by decreasing y by while statement.
![y value](https://i.gyazo.com/059596d2672950f8b06563557519b245.png)
We made a modification to prevent the timeout on SkyBlock so please check.

_I'm enjoying playing your mods every time. thank you xD_