### PR TITLE
move event.drops.clear() , add check

### DIFF
--- a/src/main/scala/com/nekokittygames/Thaumic/Tinkerer/common/items/ItemBloodSword.scala
+++ b/src/main/scala/com/nekokittygames/Thaumic/Tinkerer/common/items/ItemBloodSword.scala
@@ -85,11 +85,13 @@ object ItemBloodSword extends ItemSword(EnumHelper.addToolMaterial("TT_BLOOD",0,
           {
             val entity=event.entity
             var aspects=MobAspects.getAspects(entity.getClass)
-            for(aspect:Aspect <- aspects) {
-              var item=new ItemStack(ItemMobAspect,1)
-              ItemMobAspect.setAspect(item,aspect)
+            if (aspects!=null) {
               event.drops.clear()
-              event.drops.add(new EntityItem(player.worldObj, event.entityLiving.posX, event.entityLiving.posY, event.entityLiving.posZ,item))
+              for(aspect:Aspect <- aspects) {
+                var item=new ItemStack(ItemMobAspect,1)
+                ItemMobAspect.setAspect(item,aspect)
+                event.drops.add(new EntityItem(player.worldObj, event.entityLiving.posX, event.entityLiving.posY, event.entityLiving.posZ,item))
+              }
             }
           }
       }


### PR DESCRIPTION
Moved event.drops.clear to before the loop, so all three aspects drop.
Added a check for null aspect list, to replicate behaviour of loop if no aspect list found (mob should then drop regular loot)
fixes #882 