### PR TITLE
Add markDirty to clones

### DIFF
--- a/src/main/scala/com/nekokittygames/Thaumic/Tinkerer/common/tiles/TileBoundJar.scala
+++ b/src/main/scala/com/nekokittygames/Thaumic/Tinkerer/common/tiles/TileBoundJar.scala
@@ -56,6 +56,7 @@ class TileBoundJar  extends TileJarFillable{
     if(boundNetworkChangedEvent.network.equalsIgnoreCase(this.network))
       {
         this.worldObj.markBlockForUpdate(this.pos)
+        super.markDirty()
       }
   }
   override def markDirty(): Unit = {


### PR DESCRIPTION
Add a call to the non-overridden markDirty so neighbour states (like comparators) reflect the new contents.
fixes #895 