### PR TITLE
Typos and nuance

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/block/BlockInfusedGrain.java
+++ b/src/main/java/thaumic/tinkerer/common/block/BlockInfusedGrain.java
@@ -167,7 +167,7 @@ public class BlockInfusedGrain extends BlockCrops implements ITTinkererBlock {
 
 
     public void updateTick(World world, int x, int y, int z, Random rand) {
-        //Prevent normal growth from occuring
+        //Prevent normal growth from occurring
         //Growth takes place in the tile entity
         checkAndDropBlock(world, x, y, z);
     }

--- a/src/main/java/thaumic/tinkerer/common/core/handler/ConfigHandler.java
+++ b/src/main/java/thaumic/tinkerer/common/core/handler/ConfigHandler.java
@@ -75,7 +75,7 @@ public final class ConfigHandler {
         enableKami = Loader.isModLoaded("ThaumicTinkererKami") || propEnableKami.getBoolean(true);
 
         Property propEnableTooltips = config.get(Configuration.CATEGORY_GENERAL, "tooltipIndicators.enabled", true);
-        propEnableTooltips.comment = "Set to false to disable the [TT] tooltips in the thauminomicon.";
+        propEnableTooltips.comment = "Set to false to disable the [TT] tooltips in the Thaumonomicon.";
         useTootlipIndicators = propEnableTooltips.getBoolean(true);
 
         Property propEnableSurvivalShareTome = config.get(Configuration.CATEGORY_GENERAL, "shareTome.survival.enabled", true);
@@ -138,11 +138,11 @@ public final class ConfigHandler {
             bedrockDimensionID = propDimensionID.getInt(-19);
 
             Property oreBlacklist = config.get(CATEGORY_KAMI_GENERAL, "Bedrock dimension ore Blacklist", new String[]{"oreFirestone"});
-            oreBlacklist.comment = "These ores will not be spawned in the bedrock dimension";
+            oreBlacklist.comment = "These oredict tags will not be used to spawn ores in the bedrock dimension";
             OreClusterGenerator.blacklist = oreBlacklist.getStringList();
 
             Property propOreDensity = config.get(Configuration.CATEGORY_GENERAL, "Bedrock Dimension ore density", 1);
-            propOreDensity.comment = "The number of verticle veins of ore per chunk. Default: 1";
+            propOreDensity.comment = "The number of vertical veins of ore per chunk. Default: 1";
             OreClusterGenerator.density = propOreDensity.getInt(1);
 
             Property propShowPlacementMirrorBlocks = config.get(CATEGORY_KAMI_GENERAL, "placementMirror.blocks.show", true);


### PR DESCRIPTION
"These ores will not be spawned" suggests that an ore with the given tag will never appear. However, if a given ore has more than one oredict tag (such as "oreAluminum" and "oreAluminium", as those tags are often both given to the same ore blocks), then blacklisting one tag will not prevent the ore from spawning.

Beyond that, this is simply fixing typos