### PR TITLE
Fixed two separate bugs with Infused Crops loot tables

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
+++ b/src/main/java/thaumic/tinkerer/common/core/helper/AspectCropLootManager.java
@@ -44,7 +44,7 @@ public class AspectCropLootManager {
             int randInt = rand.nextInt(sum);
             for (Map.Entry<ItemStack, Integer> pair : aspectHashmap.entrySet()) {
                 randInt -= pair.getValue();
-                if (randInt <= 0) {
+                if (randInt < 0) {
                     return pair.getKey().copy();
                 }
             }
@@ -57,8 +57,6 @@ public class AspectCropLootManager {
     }
 
     public static void addAspectLoot(Aspect aspect, String target) {
-
-        addAspectLoot(aspect, target, 1);
         for (String ore : OreDictionary.getOreNames()) {
             if (ore.contains(WordUtils.capitalizeFully(target)) || ore.contains(target)) {
                 for (ItemStack stack : OreDictionary.getOres(ore)) {


### PR DESCRIPTION
- Removed the infused seeds bug where drop weights initialized wrongly. This bug would cause the weights of items in the loot table to become abnormally skewed, though the skew would shift whenever the JVM was reloaded. This bug was definitely a tricky one, and I believe this has been a primary culprit in a large portion of the confusion and mystery that has surrounded infused crops for all of these years.
- Removed the infused seeds bug where single-item drops registered through the ore dictionary registered twice. This one was partially hidden by the other one, and helped to hide the other one.