### PR TITLE
Osmotic Enchanter doesn't lose your settings when you add/remove a wand before starting enchantment

### DIFF
--- a/src/main/java/thaumic/tinkerer/common/block/tile/TileEnchanter.java
+++ b/src/main/java/thaumic/tinkerer/common/block/tile/TileEnchanter.java
@@ -232,8 +232,6 @@ public class TileEnchanter extends TileEntity implements ISidedInventory, IMovab
     public void markDirty() {
         super.markDirty();
         if (!worldObj.isRemote && !working) {
-            enchantments.clear();
-            levels.clear();
             worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
         }
     }


### PR DESCRIPTION
I can't tell you how many times I've configured a tool or weapon with the perfect enchantment set, realized there's no wand in the table, and added a wand before clicking the button to start the enchantment. Every time, I died a little inside. I've spoken with others, and the ones who have also done this have agreed that this behavior is _**not**_ desired. Since I was modifying the code to fix the Infused Seeds bugs, adding one more change to the mix was easy enough. So, I set the enchanter to stop scrubbing the configured enchantments every time the block is marked dirty.